### PR TITLE
Clean up Convora: persist user id, drop dead code, decouple from Heroku URL

### DIFF
--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -9,9 +9,6 @@ console.log('Convora version:', VERSION);
 const QuestionTypes = {
     AGREEMENT: 'Agreement',
     NUMERICAL: 'Numerical',
-    // MULTIPLE_CHOICE: 'Multiple Choice',
-    // CHECKBOX: 'Checkbox',
-    // RANKING: 'Ranking',
     OPEN_ENDED: 'Open Ended'
 };
 
@@ -30,8 +27,10 @@ const SortOptions = {
     MOST_CONTROVERSIAL: 'Most Controversial',
 };
 
-const SOCKET_URL = process.env.REACT_APP_SOCKET_URL || 'https://convora-e40a9ae358dc.herokuapp.com/';
-console.log('Environment SOCKET_URL:', SOCKET_URL);
+// In production the client is served by the same server it talks to, so we
+// default to a same-origin connection. Set REACT_APP_SOCKET_URL only when the
+// client runs on a different origin than the API (e.g. `vite` dev server).
+const SOCKET_URL = process.env.REACT_APP_SOCKET_URL || undefined;
 
 const socket = io(SOCKET_URL);
 
@@ -47,13 +46,19 @@ const DiscussionPage = () => {
     const [sortOption, setSortOption] = useState(SortOptions.MOST_RECENT);
     const [showUnansweredOnly, setShowUnansweredOnly] = useState(false);
     const [userId, setUserId] = useState(null);
-    const [optionsText, setOptionsText] = useState('');
     const [error, setError] = useState(null);
     const [newTopicName, setNewTopicName] = useState('');
     const [showDuplicateModal, setShowDuplicateModal] = useState(false);
 
     useEffect(() => {
-        setUserId(Math.random().toString(36).substr(2, 9));
+        // Persist a stable per-browser id so a user is recognized across reloads
+        // (otherwise vote de-duplication breaks on every refresh).
+        let id = localStorage.getItem('convora_user_id');
+        if (!id) {
+            id = crypto.randomUUID();
+            localStorage.setItem('convora_user_id', id);
+        }
+        setUserId(id);
     }, []);
 
     const handleDuplicateDiscussion = async () => {
@@ -63,9 +68,7 @@ const DiscussionPage = () => {
         }
 
         try {
-            // Remove any trailing slash from SOCKET_URL and ensure a single leading slash
-            const baseUrl = SOCKET_URL.replace(/\/$/, '').replace(/^\/+/, '/');
-            const response = await fetch(`${baseUrl}/api/duplicate-discussion`, {
+            const response = await fetch('/api/duplicate-discussion', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -157,17 +160,6 @@ const DiscussionPage = () => {
             console.log('Adding numerical question with min:', question.minValue, 'max:', question.maxValue);
         }
 
-        // Handle questions with options
-        if ([QuestionTypes.MULTIPLE_CHOICE, QuestionTypes.CHECKBOX, QuestionTypes.RANKING].includes(questionType)) {
-            const options = optionsText.split('\n').filter(option => option.trim() !== '');
-            if (options.length < 2) {
-                console.error('Failed to add question: Not enough options provided.');
-                setError('Please provide at least two options.');
-                return;
-            }
-            question.options = options;
-        }
-
         console.log('Adding question:', question);
 
         try {
@@ -178,7 +170,6 @@ const DiscussionPage = () => {
             setQuestionType(QuestionTypes.AGREEMENT);
             setMinValue(0);
             setMaxValue(100);
-            setOptionsText('');
             // Clear any previous errors
             setError(null);
         } catch (error) {
@@ -302,108 +293,6 @@ const DiscussionPage = () => {
                     </div>
                 );
             }
-            case QuestionTypes.MULTIPLE_CHOICE: {
-                if (!Array.isArray(question.options)) {
-                    console.error('Invalid options for multiple choice question:', question);
-                    return null;
-                }
-                return (
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        {question.options.map((option) => (
-                            <button
-                                key={option}
-                                onClick={() => handleVote(question.id, option)}
-                                className={`p-2 rounded-md transition duration-300 ${userVote && userVote.value === option
-                                    ? 'bg-primary text-white'
-                                    : 'bg-secondary text-white hover:bg-opacity-90'
-                                    }`}
-                            >
-                                {option}
-                            </button>
-                        ))}
-                    </div>
-                );
-            }
-            case QuestionTypes.CHECKBOX: {
-                if (optionsText.length === 0) {
-                    console.error('Invalid or missing options for checkbox question:', question);
-                    return <p>Error: This question has no options.</p>;
-                }
-                return (
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        {optionsText.map((option) => (
-                            <label key={option} className="flex items-center space-x-2">
-                                <input
-                                    type="checkbox"
-                                    checked={userVote && Array.isArray(userVote.value) && userVote.value.includes(option)}
-                                    onChange={() => {
-                                        const newValue = userVote && Array.isArray(userVote.value)
-                                            ? userVote.value.includes(option)
-                                                ? userVote.value.filter(v => v !== option)
-                                                : [...userVote.value, option]
-                                            : [option];
-                                        handleVote(question.id, newValue);
-                                    }}
-                                />
-                                <span>{option}</span>
-                            </label>
-                        ))}
-                    </div>
-                );
-            }
-
-            case QuestionTypes.RANKING: {
-                if (!Array.isArray(question.options)) {
-                    console.error('Invalid options for ranking question:', question);
-                    return null;
-                }
-                const [rankingOrder, setRankingOrder] = useState(userVote ? userVote.value : question.options);
-
-                useEffect(() => {
-                    if (userVote && Array.isArray(userVote.value)) {
-                        setRankingOrder(userVote.value);
-                    }
-                }, [userVote]);
-
-                return (
-                    <div>
-                        {rankingOrder.map((option, index) => (
-                            <div key={option} className="flex items-center space-x-2 mb-2">
-                                <span>{index + 1}.</span>
-                                <span>{option}</span>
-                                <button
-                                    onClick={() => {
-                                        const newOrder = [...rankingOrder];
-                                        if (index > 0) {
-                                            [newOrder[index], newOrder[index - 1]] = [newOrder[index - 1], newOrder[index]];
-                                            setRankingOrder(newOrder);
-                                            handleVote(question.id, newOrder);
-                                        }
-                                    }}
-                                    className="p-1 bg-secondary text-white rounded"
-                                    disabled={index === 0}
-                                >
-                                    ▲
-                                </button>
-                                <button
-                                    onClick={() => {
-                                        const newOrder = [...rankingOrder];
-                                        if (index < rankingOrder.length - 1) {
-                                            [newOrder[index], newOrder[index + 1]] = [newOrder[index + 1], newOrder[index]];
-                                            setRankingOrder(newOrder);
-                                            handleVote(question.id, newOrder);
-                                        }
-                                    }}
-                                    className="p-1 bg-secondary text-white rounded"
-                                    disabled={index === rankingOrder.length - 1}
-                                >
-                                    ▼
-                                </button>
-                            </div>
-                        ))}
-                    </div>
-                );
-            }
             case QuestionTypes.OPEN_ENDED: {
                 return <OpenEndedQuestion question={question} userVote={userVote} handleVote={handleVote} />;
             }
@@ -497,17 +386,6 @@ const DiscussionPage = () => {
                                 className="w-full p-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
                             />
                         </div>
-                    </div>
-                )}
-                {[QuestionTypes.MULTIPLE_CHOICE, QuestionTypes.CHECKBOX, QuestionTypes.RANKING].includes(questionType) && (
-                    <div className="mb-4">
-                        <label className="block mb-2">Options (one per line):</label>
-                        <textarea
-                            value={optionsText}
-                            onChange={(e) => setOptionsText(e.target.value)}
-                            className="w-full p-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
-                            rows="4"
-                        />
                     </div>
                 )}
                 <button

--- a/client/src/HomePage.jsx
+++ b/client/src/HomePage.jsx
@@ -2,7 +2,10 @@ import React, { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import io from 'socket.io-client';
 
-const SOCKET_URL = process.env.REACT_APP_SOCKET_URL || 'https://convora-e40a9ae358dc.herokuapp.com/';
+// In production the client is served by the same server it talks to, so we
+// default to a same-origin connection. Set REACT_APP_SOCKET_URL only when the
+// client runs on a different origin than the API (e.g. `vite` dev server).
+const SOCKET_URL = process.env.REACT_APP_SOCKET_URL || undefined;
 
 const HomePage = () => {
     const [discussions, setDiscussions] = useState([]);

--- a/server.js
+++ b/server.js
@@ -227,31 +227,6 @@ async function addQuestion(topic, question) {
   }
 }
 
-// might get rid of this
-async function migrateOptionsToJson() {
-  const client = await pool.connect();
-  try {
-    await client.query('BEGIN');
-
-    const result = await client.query('SELECT id, options FROM questions WHERE options IS NOT NULL');
-
-    for (const row of result.rows) {
-      const parsedOptions = parseOptions(row.options);
-      await client.query('UPDATE questions SET options = $1 WHERE id = $2', [JSON.stringify(parsedOptions), row.id]);
-    }
-
-    await client.query('COMMIT');
-    console.log('Migration completed successfully');
-  } catch (e) {
-    await client.query('ROLLBACK');
-    console.error('Error during migration:', e);
-  } finally {
-    client.release();
-  }
-}
-migrateOptionsToJson().catch(console.error);
-// might get rid of above
-
 async function addVote(questionId, vote, userId) {
   console.log('Adding vote:', questionId, vote, userId);
   const client = await pool.connect();
@@ -317,8 +292,7 @@ app.get('/api/discussions', async (req, res) => {
   }
 });
 
-// for some reason I'm getting duplicate forward slashes, so just throwing this hack in to fix it
-app.post(['/api/duplicate-discussion', '//api/duplicate-discussion'], async (req, res) => {
+app.post('/api/duplicate-discussion', async (req, res) => {
   const { originalTopic, newTopic } = req.body;
   console.log(`Attempting to duplicate discussion. Original: ${originalTopic}, New: ${newTopic}`);
 


### PR DESCRIPTION
Cleanup pass over the Convora codebase, verified end-to-end against a local restore of the production backup (`latest.dump`): React app, REST API, and WebSocket voting all confirmed working.

- **Persistent identity:** `userId` is now stored in `localStorage` instead of regenerated on every page load, so one-vote-per-user actually holds across reloads.
- **Host-agnostic:** the hardcoded `convora-…herokuapp.com` URL is replaced with a same-origin default (set `REACT_APP_SOCKET_URL` only for the split `vite` dev server), so redeploying to a new URL needs no code changes.
- **Dead code removed:** the three disabled question types (multiple-choice/checkbox/ranking) — including a broken checkbox branch and a rules-of-hooks violation in the ranking branch — plus the migrate-options-on-boot routine (column is already `jsonb`) and the `//api` double-slash duplicate-discussion hack.

Net −145 lines. No behavior change for the live Agreement/Numerical/Open-Ended flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)