### PR TITLE
Add Brainstorm question type for multiple answers per person

### DIFF
--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -12,7 +12,16 @@ const QuestionTypes = {
     // MULTIPLE_CHOICE: 'Multiple Choice',
     // CHECKBOX: 'Checkbox',
     // RANKING: 'Ranking',
-    OPEN_ENDED: 'Open Ended'
+    OPEN_ENDED: 'Open Ended',
+    BRAINSTORM: 'Brainstorm'
+};
+
+// Shown under the type picker so creators understand what each type does.
+const QuestionTypeDescriptions = {
+    [QuestionTypes.AGREEMENT]: 'Each participant picks one option from Strongly Agree to Strongly Disagree.',
+    [QuestionTypes.NUMERICAL]: 'Each participant submits a single number on a slider between your min and max.',
+    [QuestionTypes.OPEN_ENDED]: 'Each participant gives one free-text response, which they can edit later. One answer per person.',
+    [QuestionTypes.BRAINSTORM]: 'Each participant can add as many separate ideas as they want, and remove their own. Many answers per person.'
 };
 
 const VoteOptions = {
@@ -191,6 +200,13 @@ const DiscussionPage = () => {
         console.log('Voting:', questionId, value);
         socket.emit('vote', topic, questionId, value, userId);
         setSliderValues(prev => ({ ...prev, [questionId]: undefined }));
+    };
+
+    // Brainstorm answers are individual rows, so they're removed by vote id
+    // (a participant can only delete their own).
+    const handleDeleteVote = (questionId, voteId) => {
+        console.log('Deleting vote:', questionId, voteId);
+        socket.emit('deleteVote', topic, voteId, userId);
     };
 
     const handleSliderChange = (questionId, value) => {
@@ -407,6 +423,9 @@ const DiscussionPage = () => {
             case QuestionTypes.OPEN_ENDED: {
                 return <OpenEndedQuestion question={question} userVote={userVote} handleVote={handleVote} />;
             }
+            case QuestionTypes.BRAINSTORM: {
+                return <BrainstormQuestion question={question} userId={userId} handleVote={handleVote} handleDeleteVote={handleDeleteVote} />;
+            }
 
             default:
                 console.warn('Unknown question type:', question.type);
@@ -476,6 +495,9 @@ const DiscussionPage = () => {
                             <option key={type} value={type}>{type}</option>
                         ))}
                     </select>
+                    {QuestionTypeDescriptions[questionType] && (
+                        <p className="mt-2 text-sm text-gray-500">{QuestionTypeDescriptions[questionType]}</p>
+                    )}
                 </div>
                 {questionType === QuestionTypes.NUMERICAL && (
                     <div className="mb-4 flex space-x-4">
@@ -608,4 +630,78 @@ OpenEndedQuestion.propTypes = {
     }),
     handleVote: PropTypes.func.isRequired
 };
+
+// Unlike Open Ended (one editable response per person), Brainstorm lets each
+// participant add any number of separate ideas and delete their own.
+const BrainstormQuestion = ({ question, userId, handleVote, handleDeleteVote }) => {
+    const [idea, setIdea] = useState('');
+    const votes = question.votes || [];
+
+    const submitIdea = () => {
+        if (idea.trim() === '') {
+            return;
+        }
+        console.log('Submitting brainstorm idea:', idea);
+        handleVote(question.id, idea.trim());
+        setIdea('');
+    };
+
+    return (
+        <div>
+            <textarea
+                value={idea}
+                onChange={(e) => setIdea(e.target.value)}
+                className="w-full p-2 border rounded mb-2"
+                rows="3"
+                placeholder="Add an idea (you can add as many as you like)"
+            />
+            <button
+                onClick={submitIdea}
+                disabled={idea.trim() === ''}
+                className="px-4 py-2 bg-primary text-white rounded hover:bg-opacity-90 transition duration-300 mb-4 disabled:opacity-50"
+            >
+                Add Idea
+            </button>
+
+            {votes.length > 0 && (
+                <div className="mt-4">
+                    <h3 className="font-semibold mb-2">All Ideas ({votes.length}):</h3>
+                    <ul className="list-disc pl-5">
+                        {votes.map((vote) => (
+                            <li key={vote.id} className="mb-2 flex items-start justify-between">
+                                <span>
+                                    {vote.value}
+                                    {vote.userId === userId && " (You)"}
+                                </span>
+                                {vote.userId === userId && (
+                                    <button
+                                        onClick={() => handleDeleteVote(question.id, vote.id)}
+                                        className="ml-4 text-sm text-red-500 hover:text-red-700"
+                                    >
+                                        Delete
+                                    </button>
+                                )}
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+        </div>
+    );
+};
+
+BrainstormQuestion.propTypes = {
+    question: PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        votes: PropTypes.arrayOf(PropTypes.shape({
+            id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+            userId: PropTypes.string.isRequired,
+            value: PropTypes.string.isRequired
+        }))
+    }).isRequired,
+    userId: PropTypes.string,
+    handleVote: PropTypes.func.isRequired,
+    handleDeleteVote: PropTypes.func.isRequired
+};
+
 export default DiscussionPage;

--- a/server.js
+++ b/server.js
@@ -103,6 +103,17 @@ io.on('connection', (socket) => {
     }
   });
 
+  socket.on('deleteVote', async (topic, voteId, userId) => {
+    try {
+      await deleteVote(voteId, userId);
+      const questions = await getQuestions(topic);
+      io.to(topic).emit('questions', questions);
+    } catch (error) {
+      console.error('Error deleting vote:', error);
+      socket.emit('error', { message: 'Failed to delete vote' });
+    }
+  });
+
   socket.on('disconnect', () => {
     console.log('Client disconnected');
   });
@@ -258,6 +269,24 @@ async function addVote(questionId, vote, userId) {
   try {
     await client.query('BEGIN');
 
+    // Brainstorm questions allow each user to add many separate ideas, so every
+    // submission is a brand new row rather than an update to a single answer.
+    const typeResult = await client.query(
+      'SELECT type FROM questions WHERE id = $1',
+      [questionId]
+    );
+    const questionType = typeResult.rows[0] && typeResult.rows[0].type;
+
+    if (questionType === 'Brainstorm') {
+      await client.query(
+        'INSERT INTO votes (question_id, user_id, value) VALUES ($1, $2, $3)',
+        [questionId, userId, vote]
+      );
+      await client.query('COMMIT');
+      console.log('Brainstorm idea added successfully');
+      return;
+    }
+
     // Check if the user has already voted on this question
     const existingVoteResult = await client.query(
       'SELECT * FROM votes WHERE question_id = $1 AND user_id = $2',
@@ -303,6 +332,17 @@ async function addVote(questionId, vote, userId) {
   } finally {
     client.release();
   }
+}
+
+// Removes a single vote (used for Brainstorm ideas). The user_id check ensures a
+// participant can only delete their own ideas.
+async function deleteVote(voteId, userId) {
+  console.log('Deleting vote:', voteId, userId);
+  await pool.query(
+    'DELETE FROM votes WHERE id = $1 AND user_id = $2',
+    [voteId, userId]
+  );
+  console.log('Vote deleted successfully');
 }
 
 app.get('/api/discussions', async (req, res) => {


### PR DESCRIPTION
Adds a **Brainstorm** question type alongside Open Ended. Open Ended stays one editable response per participant; Brainstorm lets each participant add any number of separate ideas and delete their own. Server-side, `addVote` inserts a new `votes` row for Brainstorm questions (bypassing the one-vote-per-user logic) and a new `deleteVote` handler removes a single idea scoped to its owner. Client-side adds a `BrainstormQuestion` component (add/list/delete ideas) and renders per-type descriptions under the picker so the Open Ended vs Brainstorm distinction is clear. No schema migration needed — multiple rows per user is already representable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)