### PR TITLE
Foundation: persistent identity + pseudonyms, results viz, dead-code cleanup

### DIFF
--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import io from 'socket.io-client';
+import { getIdentity, regeneratePseudonym } from './identity';
 
 const VERSION = '0.1.8';
 console.log('Convora version:', VERSION);
@@ -9,9 +10,6 @@ console.log('Convora version:', VERSION);
 const QuestionTypes = {
     AGREEMENT: 'Agreement',
     NUMERICAL: 'Numerical',
-    // MULTIPLE_CHOICE: 'Multiple Choice',
-    // CHECKBOX: 'Checkbox',
-    // RANKING: 'Ranking',
     OPEN_ENDED: 'Open Ended'
 };
 
@@ -30,6 +28,16 @@ const SortOptions = {
     MOST_CONTROVERSIAL: 'Most Controversial',
 };
 
+// Display order for the agreement divergence bar: disagreement (left, red) to
+// agreement (right, green). Full literal class names so Tailwind keeps them.
+const AGREEMENT_SCALE = [
+    { key: VoteOptions.STRONGLY_DISAGREE, label: 'Strongly Disagree', bar: 'bg-red-600', dot: 'bg-red-600' },
+    { key: VoteOptions.DISAGREE, label: 'Disagree', bar: 'bg-red-400', dot: 'bg-red-400' },
+    { key: VoteOptions.UNSURE, label: 'Unsure', bar: 'bg-gray-400', dot: 'bg-gray-400' },
+    { key: VoteOptions.AGREE, label: 'Agree', bar: 'bg-green-400', dot: 'bg-green-400' },
+    { key: VoteOptions.STRONGLY_AGREE, label: 'Strongly Agree', bar: 'bg-green-600', dot: 'bg-green-600' },
+];
+
 const SOCKET_URL = process.env.REACT_APP_SOCKET_URL || 'https://convora-e40a9ae358dc.herokuapp.com/';
 console.log('Environment SOCKET_URL:', SOCKET_URL);
 
@@ -47,14 +55,21 @@ const DiscussionPage = () => {
     const [sortOption, setSortOption] = useState(SortOptions.MOST_RECENT);
     const [showUnansweredOnly, setShowUnansweredOnly] = useState(false);
     const [userId, setUserId] = useState(null);
-    const [optionsText, setOptionsText] = useState('');
+    const [pseudonym, setPseudonym] = useState('');
     const [error, setError] = useState(null);
     const [newTopicName, setNewTopicName] = useState('');
     const [showDuplicateModal, setShowDuplicateModal] = useState(false);
 
     useEffect(() => {
-        setUserId(Math.random().toString(36).substr(2, 9));
+        const identity = getIdentity();
+        setUserId(identity.userId);
+        setPseudonym(identity.pseudonym);
     }, []);
+
+    const handleRegeneratePseudonym = () => {
+        const updated = regeneratePseudonym();
+        setPseudonym(updated.pseudonym);
+    };
 
     const handleDuplicateDiscussion = async () => {
         if (newTopicName.trim() === '') {
@@ -157,17 +172,6 @@ const DiscussionPage = () => {
             console.log('Adding numerical question with min:', question.minValue, 'max:', question.maxValue);
         }
 
-        // Handle questions with options
-        if ([QuestionTypes.MULTIPLE_CHOICE, QuestionTypes.CHECKBOX, QuestionTypes.RANKING].includes(questionType)) {
-            const options = optionsText.split('\n').filter(option => option.trim() !== '');
-            if (options.length < 2) {
-                console.error('Failed to add question: Not enough options provided.');
-                setError('Please provide at least two options.');
-                return;
-            }
-            question.options = options;
-        }
-
         console.log('Adding question:', question);
 
         try {
@@ -178,7 +182,6 @@ const DiscussionPage = () => {
             setQuestionType(QuestionTypes.AGREEMENT);
             setMinValue(0);
             setMaxValue(100);
-            setOptionsText('');
             // Clear any previous errors
             setError(null);
         } catch (error) {
@@ -189,7 +192,7 @@ const DiscussionPage = () => {
 
     const handleVote = (questionId, value) => {
         console.log('Voting:', questionId, value);
-        socket.emit('vote', topic, questionId, value, userId);
+        socket.emit('vote', topic, questionId, value, userId, pseudonym);
         setSliderValues(prev => ({ ...prev, [questionId]: undefined }));
     };
 
@@ -246,23 +249,26 @@ const DiscussionPage = () => {
         switch (question.type) {
             case QuestionTypes.AGREEMENT:
                 return (
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        {Object.values(VoteOptions).map((option) => (
-                            <div key={option} className="flex items-center justify-between bg-gray-100 p-3 rounded-md">
-                                <span className="font-medium">
-                                    {option}: {question.votes ? question.votes.filter(v => v.value === option).length : 0}
-                                </span>
-                                <button
-                                    onClick={() => handleVote(question.id, option)}
-                                    className={`px-4 py-2 rounded-md transition duration-300 ${userVote && userVote.value === option
-                                        ? 'bg-primary text-white hover:bg-opacity-90'
-                                        : 'bg-secondary text-white hover:bg-opacity-90'
-                                        }`}
-                                >
-                                    {userVote && userVote.value === option ? 'Undo Vote' : 'Vote'}
-                                </button>
-                            </div>
-                        ))}
+                    <div>
+                        <AgreementResults question={question} />
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            {Object.values(VoteOptions).map((option) => (
+                                <div key={option} className="flex items-center justify-between bg-gray-100 p-3 rounded-md">
+                                    <span className="font-medium">
+                                        {option}: {question.votes ? question.votes.filter(v => v.value === option).length : 0}
+                                    </span>
+                                    <button
+                                        onClick={() => handleVote(question.id, option)}
+                                        className={`px-4 py-2 rounded-md transition duration-300 ${userVote && userVote.value === option
+                                            ? 'bg-primary text-white hover:bg-opacity-90'
+                                            : 'bg-secondary text-white hover:bg-opacity-90'
+                                            }`}
+                                    >
+                                        {userVote && userVote.value === option ? 'Undo Vote' : 'Vote'}
+                                    </button>
+                                </div>
+                            ))}
+                        </div>
                     </div>
                 );
             case QuestionTypes.NUMERICAL: {
@@ -280,6 +286,7 @@ const DiscussionPage = () => {
 
                 return (
                     <div className="mt-4">
+                        <NumericalResults question={question} minValue={minValue} maxValue={maxValue} />
                         <input
                             type="range"
                             min={minValue}
@@ -302,108 +309,6 @@ const DiscussionPage = () => {
                     </div>
                 );
             }
-            case QuestionTypes.MULTIPLE_CHOICE: {
-                if (!Array.isArray(question.options)) {
-                    console.error('Invalid options for multiple choice question:', question);
-                    return null;
-                }
-                return (
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        {question.options.map((option) => (
-                            <button
-                                key={option}
-                                onClick={() => handleVote(question.id, option)}
-                                className={`p-2 rounded-md transition duration-300 ${userVote && userVote.value === option
-                                    ? 'bg-primary text-white'
-                                    : 'bg-secondary text-white hover:bg-opacity-90'
-                                    }`}
-                            >
-                                {option}
-                            </button>
-                        ))}
-                    </div>
-                );
-            }
-            case QuestionTypes.CHECKBOX: {
-                if (optionsText.length === 0) {
-                    console.error('Invalid or missing options for checkbox question:', question);
-                    return <p>Error: This question has no options.</p>;
-                }
-                return (
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        {optionsText.map((option) => (
-                            <label key={option} className="flex items-center space-x-2">
-                                <input
-                                    type="checkbox"
-                                    checked={userVote && Array.isArray(userVote.value) && userVote.value.includes(option)}
-                                    onChange={() => {
-                                        const newValue = userVote && Array.isArray(userVote.value)
-                                            ? userVote.value.includes(option)
-                                                ? userVote.value.filter(v => v !== option)
-                                                : [...userVote.value, option]
-                                            : [option];
-                                        handleVote(question.id, newValue);
-                                    }}
-                                />
-                                <span>{option}</span>
-                            </label>
-                        ))}
-                    </div>
-                );
-            }
-
-            case QuestionTypes.RANKING: {
-                if (!Array.isArray(question.options)) {
-                    console.error('Invalid options for ranking question:', question);
-                    return null;
-                }
-                const [rankingOrder, setRankingOrder] = useState(userVote ? userVote.value : question.options);
-
-                useEffect(() => {
-                    if (userVote && Array.isArray(userVote.value)) {
-                        setRankingOrder(userVote.value);
-                    }
-                }, [userVote]);
-
-                return (
-                    <div>
-                        {rankingOrder.map((option, index) => (
-                            <div key={option} className="flex items-center space-x-2 mb-2">
-                                <span>{index + 1}.</span>
-                                <span>{option}</span>
-                                <button
-                                    onClick={() => {
-                                        const newOrder = [...rankingOrder];
-                                        if (index > 0) {
-                                            [newOrder[index], newOrder[index - 1]] = [newOrder[index - 1], newOrder[index]];
-                                            setRankingOrder(newOrder);
-                                            handleVote(question.id, newOrder);
-                                        }
-                                    }}
-                                    className="p-1 bg-secondary text-white rounded"
-                                    disabled={index === 0}
-                                >
-                                    ▲
-                                </button>
-                                <button
-                                    onClick={() => {
-                                        const newOrder = [...rankingOrder];
-                                        if (index < rankingOrder.length - 1) {
-                                            [newOrder[index], newOrder[index + 1]] = [newOrder[index + 1], newOrder[index]];
-                                            setRankingOrder(newOrder);
-                                            handleVote(question.id, newOrder);
-                                        }
-                                    }}
-                                    className="p-1 bg-secondary text-white rounded"
-                                    disabled={index === rankingOrder.length - 1}
-                                >
-                                    ▼
-                                </button>
-                            </div>
-                        ))}
-                    </div>
-                );
-            }
             case QuestionTypes.OPEN_ENDED: {
                 return <OpenEndedQuestion question={question} userVote={userVote} handleVote={handleVote} />;
             }
@@ -418,7 +323,19 @@ const DiscussionPage = () => {
 
     return (
         <div className="max-w-4xl mx-auto mt-10 px-4">
-            <h1 className="text-4xl font-bold mb-8 text-center text-gray-800">Discussion: {topic}</h1>
+            <h1 className="text-4xl font-bold mb-2 text-center text-gray-800">Discussion: {topic}</h1>
+
+            {/* Participant identity */}
+            <div className="mb-8 text-center text-sm text-gray-600">
+                You are <span className="font-semibold text-gray-800">{pseudonym || '…'}</span>
+                <button
+                    onClick={handleRegeneratePseudonym}
+                    className="ml-2 text-primary hover:underline"
+                    title="Get a new pseudonym"
+                >
+                    (change)
+                </button>
+            </div>
 
             {/* Duplicate Discussion Button */}
             <button
@@ -499,17 +416,6 @@ const DiscussionPage = () => {
                         </div>
                     </div>
                 )}
-                {[QuestionTypes.MULTIPLE_CHOICE, QuestionTypes.CHECKBOX, QuestionTypes.RANKING].includes(questionType) && (
-                    <div className="mb-4">
-                        <label className="block mb-2">Options (one per line):</label>
-                        <textarea
-                            value={optionsText}
-                            onChange={(e) => setOptionsText(e.target.value)}
-                            className="w-full p-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
-                            rows="4"
-                        />
-                    </div>
-                )}
                 <button
                     onClick={handleAddQuestion}
                     className="w-full bg-primary text-white py-3 rounded-md hover:bg-opacity-90 transition duration-300"
@@ -580,13 +486,19 @@ const OpenEndedQuestion = ({ question, userVote, handleVote }) => {
             {question.votes && question.votes.length > 0 && (
                 <div className="mt-4">
                     <h3 className="font-semibold mb-2">All Responses:</h3>
-                    <ul className="list-disc pl-5">
-                        {question.votes.map((vote, index) => (
-                            <li key={index} className="mb-2">
-                                {vote.value}
-                                {vote.userId === userVote?.userId && " (Your response)"}
-                            </li>
-                        ))}
+                    <ul className="space-y-2">
+                        {question.votes.map((vote, index) => {
+                            const isYou = vote.userId === userVote?.userId;
+                            return (
+                                <li key={index} className="bg-gray-50 rounded-md p-3">
+                                    <div className="text-xs font-semibold text-gray-500 mb-1">
+                                        {vote.pseudonym || 'Anonymous'}
+                                        {isYou && ' (you)'}
+                                    </div>
+                                    <div className="text-gray-800 whitespace-pre-wrap">{vote.value}</div>
+                                </li>
+                            );
+                        })}
                     </ul>
                 </div>
             )}
@@ -599,7 +511,8 @@ OpenEndedQuestion.propTypes = {
         id: PropTypes.string.isRequired,
         votes: PropTypes.arrayOf(PropTypes.shape({
             userId: PropTypes.string.isRequired,
-            value: PropTypes.string.isRequired
+            value: PropTypes.string.isRequired,
+            pseudonym: PropTypes.string
         }))
     }).isRequired,
     userVote: PropTypes.shape({
@@ -608,4 +521,128 @@ OpenEndedQuestion.propTypes = {
     }),
     handleVote: PropTypes.func.isRequired
 };
+
+// Stacked divergence bar + summary for an Agreement question. Shows at a glance
+// how opinion splits, and labels the statement as consensus or divisive.
+const AgreementResults = ({ question }) => {
+    const votes = question.votes || [];
+    const total = votes.length;
+
+    const counts = AGREEMENT_SCALE.map(seg => ({
+        ...seg,
+        count: votes.filter(v => v.value === seg.key).length,
+    }));
+
+    if (total === 0) {
+        return <p className="text-sm text-gray-500 mb-4">No votes yet — be the first to weigh in.</p>;
+    }
+
+    const agreeCount = counts.filter(c => c.key === VoteOptions.AGREE || c.key === VoteOptions.STRONGLY_AGREE)
+        .reduce((sum, c) => sum + c.count, 0);
+    const disagreeCount = counts.filter(c => c.key === VoteOptions.DISAGREE || c.key === VoteOptions.STRONGLY_DISAGREE)
+        .reduce((sum, c) => sum + c.count, 0);
+    const agreePct = Math.round((agreeCount / total) * 100);
+    const disagreePct = Math.round((disagreeCount / total) * 100);
+
+    // Divisive when the room is split roughly evenly between agree and disagree;
+    // consensus when one side clearly dominates.
+    const decided = agreeCount + disagreeCount;
+    let badge = null;
+    if (decided >= 2) {
+        const split = Math.min(agreeCount, disagreeCount) / decided; // 0..0.5
+        if (split >= 0.4) {
+            badge = <span className="px-2 py-0.5 text-xs font-semibold rounded-full bg-amber-100 text-amber-800">Divisive</span>;
+        } else if (split <= 0.15) {
+            badge = <span className="px-2 py-0.5 text-xs font-semibold rounded-full bg-emerald-100 text-emerald-800">Consensus</span>;
+        }
+    }
+
+    return (
+        <div className="mb-4">
+            <div className="flex items-center justify-between mb-2">
+                <span className="text-sm text-gray-600">
+                    {total} {total === 1 ? 'vote' : 'votes'} · {agreePct}% agree · {disagreePct}% disagree
+                </span>
+                {badge}
+            </div>
+            <div className="flex w-full h-4 rounded-full overflow-hidden bg-gray-200">
+                {counts.map(seg => seg.count > 0 && (
+                    <div
+                        key={seg.key}
+                        className={seg.bar}
+                        style={{ width: `${(seg.count / total) * 100}%` }}
+                        title={`${seg.label}: ${seg.count}`}
+                    />
+                ))}
+            </div>
+            <div className="flex flex-wrap gap-x-4 gap-y-1 mt-2">
+                {counts.map(seg => (
+                    <span key={seg.key} className="flex items-center text-xs text-gray-600">
+                        <span className={`inline-block w-2.5 h-2.5 rounded-full mr-1 ${seg.dot}`} />
+                        {seg.label}: {seg.count}
+                    </span>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+AgreementResults.propTypes = {
+    question: PropTypes.shape({
+        votes: PropTypes.array,
+    }).isRequired,
+};
+
+// Summary stats + histogram for a Numerical question.
+const NumericalResults = ({ question, minValue, maxValue }) => {
+    const values = (question.votes || [])
+        .map(v => parseInt(v.value))
+        .filter(n => !Number.isNaN(n));
+    const total = values.length;
+
+    if (total === 0) {
+        return <p className="text-sm text-gray-500 mb-2">No responses yet — drag the slider to add yours.</p>;
+    }
+
+    const average = values.reduce((sum, n) => sum + n, 0) / total;
+    const range = Math.max(maxValue - minValue, 1);
+
+    // Bucket values into up to 10 bins across the [min, max] range.
+    const binCount = Math.min(10, range + 1);
+    const bins = new Array(binCount).fill(0);
+    values.forEach(n => {
+        const clamped = Math.min(Math.max(n, minValue), maxValue);
+        let idx = Math.floor(((clamped - minValue) / range) * binCount);
+        if (idx >= binCount) idx = binCount - 1; // include the max edge
+        bins[idx] += 1;
+    });
+    const tallestBin = Math.max(...bins);
+
+    return (
+        <div className="mb-2">
+            <div className="text-sm text-gray-600 mb-2">
+                {total} {total === 1 ? 'response' : 'responses'} · average <span className="font-semibold">{average.toFixed(1)}</span>
+            </div>
+            <div className="flex items-end gap-1 h-16">
+                {bins.map((count, i) => (
+                    <div
+                        key={i}
+                        className="flex-1 bg-primary rounded-t"
+                        style={{ height: tallestBin > 0 ? `${(count / tallestBin) * 100}%` : '0%' }}
+                        title={`${count} ${count === 1 ? 'response' : 'responses'}`}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+};
+
+NumericalResults.propTypes = {
+    question: PropTypes.shape({
+        votes: PropTypes.array,
+    }).isRequired,
+    minValue: PropTypes.number.isRequired,
+    maxValue: PropTypes.number.isRequired,
+};
+
 export default DiscussionPage;

--- a/client/src/identity.js
+++ b/client/src/identity.js
@@ -1,0 +1,83 @@
+// Persistent anonymous identity for Convora participants.
+//
+// A participant gets a stable userId (used for vote ownership) and a friendly
+// adjective-animal pseudonym (e.g. "Happy Badger") so people can refer to each
+// other in open-ended discussion. Both are stored together in localStorage so a
+// page refresh keeps the same identity and the same votes.
+
+const STORAGE_KEY = 'convora_identity';
+
+const ADJECTIVES = [
+    'Happy', 'Brave', 'Clever', 'Gentle', 'Swift', 'Mighty', 'Curious', 'Calm',
+    'Bold', 'Bright', 'Cheerful', 'Daring', 'Eager', 'Fierce', 'Friendly', 'Jolly',
+    'Kind', 'Lively', 'Loyal', 'Lucky', 'Merry', 'Nimble', 'Noble', 'Plucky',
+    'Proud', 'Quick', 'Quiet', 'Sleepy', 'Sly', 'Snappy', 'Sunny', 'Witty',
+    'Zesty', 'Breezy', 'Cozy', 'Dapper', 'Fuzzy', 'Glad', 'Hardy', 'Humble',
+    'Jazzy', 'Keen', 'Mellow', 'Peppy', 'Rosy', 'Spry', 'Tidy', 'Wise',
+];
+
+const ANIMALS = [
+    'Badger', 'Otter', 'Fox', 'Falcon', 'Panda', 'Heron', 'Lynx', 'Moose',
+    'Beaver', 'Bison', 'Cobra', 'Crane', 'Dingo', 'Eagle', 'Ferret', 'Gecko',
+    'Hawk', 'Ibis', 'Jaguar', 'Koala', 'Lemur', 'Marmot', 'Newt', 'Ocelot',
+    'Puffin', 'Quokka', 'Raccoon', 'Salmon', 'Tapir', 'Urchin', 'Viper', 'Walrus',
+    'Yak', 'Zebra', 'Wombat', 'Stoat', 'Robin', 'Possum', 'Mink', 'Lark',
+    'Kestrel', 'Hare', 'Gull', 'Finch', 'Egret', 'Civet', 'Bat', 'Antelope',
+];
+
+function pick(list) {
+    return list[Math.floor(Math.random() * list.length)];
+}
+
+export function generatePseudonym() {
+    return `${pick(ADJECTIVES)} ${pick(ANIMALS)}`;
+}
+
+function generateUserId() {
+    // Longer than the old 9-char id to make collisions across participants
+    // vanishingly unlikely now that ids are persisted and reused.
+    return (
+        Math.random().toString(36).slice(2, 10) +
+        Math.random().toString(36).slice(2, 10)
+    );
+}
+
+function readStored() {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed.userId === 'string' && typeof parsed.pseudonym === 'string') {
+            return parsed;
+        }
+        return null;
+    } catch (e) {
+        console.warn('Failed to read stored identity:', e);
+        return null;
+    }
+}
+
+function writeStored(identity) {
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(identity));
+    } catch (e) {
+        console.warn('Failed to persist identity:', e);
+    }
+}
+
+// Returns the stored identity, creating and persisting one on first use.
+export function getIdentity() {
+    const existing = readStored();
+    if (existing) return existing;
+    const identity = { userId: generateUserId(), pseudonym: generatePseudonym() };
+    writeStored(identity);
+    return identity;
+}
+
+// Keeps the same userId (so votes stay attributed) but assigns a new pseudonym.
+export function regeneratePseudonym() {
+    const current = getIdentity();
+    const updated = { ...current, pseudonym: generatePseudonym() };
+    writeStored(updated);
+    return updated;
+}

--- a/server.js
+++ b/server.js
@@ -92,9 +92,9 @@ io.on('connection', (socket) => {
     }
   });
 
-  socket.on('vote', async (topic, questionId, vote, userId) => {
+  socket.on('vote', async (topic, questionId, vote, userId, pseudonym) => {
     try {
-      await addVote(questionId, vote, userId);
+      await addVote(questionId, vote, userId, pseudonym);
       const questions = await getQuestions(topic);
       io.to(topic).emit('questions', questions);
     } catch (error) {
@@ -160,9 +160,10 @@ async function getQuestions(topic) {
         json_build_object(
           'id', v.id,
           'value', v.value,
-          'userId', v.user_id
+          'userId', v.user_id,
+          'pseudonym', v.pseudonym
         ) ORDER BY v.id
-      ) FILTER (WHERE v.id IS NOT NULL), '[]'::json) as votes 
+      ) FILTER (WHERE v.id IS NOT NULL), '[]'::json) as votes
     FROM questions q
     JOIN discussions d ON q.discussion_id = d.id
     LEFT JOIN votes v ON q.id = v.question_id 
@@ -252,8 +253,20 @@ async function migrateOptionsToJson() {
 migrateOptionsToJson().catch(console.error);
 // might get rid of above
 
-async function addVote(questionId, vote, userId) {
-  console.log('Adding vote:', questionId, vote, userId);
+// Add the pseudonym column to votes if it doesn't already exist. Idempotent so
+// it's safe to run on every boot.
+async function migrateAddPseudonymColumn() {
+  try {
+    await pool.query('ALTER TABLE votes ADD COLUMN IF NOT EXISTS pseudonym TEXT');
+    console.log('Pseudonym column migration completed');
+  } catch (e) {
+    console.error('Error adding pseudonym column:', e);
+  }
+}
+migrateAddPseudonymColumn().catch(console.error);
+
+async function addVote(questionId, vote, userId, pseudonym) {
+  console.log('Adding vote:', questionId, vote, userId, pseudonym);
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
@@ -267,11 +280,11 @@ async function addVote(questionId, vote, userId) {
     if (existingVoteResult.rows.length > 0) {
       console.log('User has already voted');
       const existingVote = existingVoteResult.rows[0];
-      // For checkbox, we need to handle multiple values
+      // Arrays (e.g. multi-value responses) are stored as JSON strings
       if (Array.isArray(vote)) {
         await client.query(
-          'UPDATE votes SET value = $1 WHERE id = $2',
-          [JSON.stringify(vote), existingVote.id]
+          'UPDATE votes SET value = $1, pseudonym = $2 WHERE id = $3',
+          [JSON.stringify(vote), pseudonym, existingVote.id]
         );
       } else if (existingVote.value === vote) {
         console.log('Voting for a option they already voted for');
@@ -282,15 +295,15 @@ async function addVote(questionId, vote, userId) {
       } else {
         console.log('Voting for a different option');
         await client.query(
-          'UPDATE votes SET value = $1 WHERE id = $2',
-          [vote, existingVote.id]
+          'UPDATE votes SET value = $1, pseudonym = $2 WHERE id = $3',
+          [vote, pseudonym, existingVote.id]
         );
       }
     } else {
       console.log('User has not voted yet');
       await client.query(
-        'INSERT INTO votes (question_id, user_id, value) VALUES ($1, $2, $3)',
-        [questionId, userId, Array.isArray(vote) ? JSON.stringify(vote) : vote]
+        'INSERT INTO votes (question_id, user_id, value, pseudonym) VALUES ($1, $2, $3, $4)',
+        [questionId, userId, Array.isArray(vote) ? JSON.stringify(vote) : vote, pseudonym]
       );
     }
 


### PR DESCRIPTION
## What & why

First of three planned PRs adding deliberation features to Convora. This one is the foundation everything else builds on.

### 1. Persistent identity + pseudonyms
Previously `userId` was `Math.random()` regenerated on every page load, so a refresh lost your votes and broke "Undo Vote"/"Update Vote" and the "show unanswered only" filter. Now:
- `client/src/identity.js` persists `{userId, pseudonym}` in `localStorage`.
- Each participant gets a friendly **adjective-animal** pseudonym (e.g. *Happy Badger*) with a **change** button to re-roll it (keeps the same `userId`, so votes stay attributed).
- Votes carry the pseudonym (idempotent migration adds `votes.pseudonym`), and open-ended responses are attributed by pseudonym so people can refer to each other.

### 2. Results visualization
- **Agreement** questions: stacked divergence bar (disagree → agree), a `votes · % agree · % disagree` summary, and a **Divisive**/**Consensus** badge — this is the README's core "find what people disagree on" payoff, made visible.
- **Numerical** questions: response count, average, and a histogram.

### 3. Dead-code cleanup
Removed the commented-out Multiple Choice / Checkbox / Ranking question types and their dead (and partly buggy — the Checkbox branch read `optionsText` instead of `question.options`) render branches and form fields.

## Test results
- ✅ `npm run build` (client) succeeds
- ✅ ESLint clean (only the pre-existing "React version not specified" warning)
- ✅ `node --check server.js`
- ⚠️ Not runtime-tested against Postgres (none installed in this workspace). The schema change is `ALTER TABLE votes ADD COLUMN IF NOT EXISTS pseudonym TEXT`, safe to re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)