### PR TITLE
Live & social + Moderation & dedup (carries PR #24's content too — it never reached main)

### DIFF
--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -157,6 +157,9 @@ const DiscussionPage = () => {
         socket.on('questions', handleQuestionsUpdate);
         socket.on('presence', setPresence);
         return () => {
+            // Leave the room so the server stops counting this client toward the
+            // discussion's presence once the page unmounts (e.g. navigating home).
+            socket.emit('leaveDiscussion', topic);
             socket.off('questions', handleQuestionsUpdate);
             socket.off('presence', setPresence);
         };

--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -63,8 +63,18 @@ const DiscussionPage = () => {
     const [showShareModal, setShowShareModal] = useState(false);
     const [presence, setPresence] = useState(0);
     const [copied, setCopied] = useState(false);
+    const [adminToken, setAdminToken] = useState(null);
+    const [discussionState, setDiscussionState] = useState({ locked: false, hasModerator: false });
+    const [similarPrompt, setSimilarPrompt] = useState(null);
+    const [adminLinkCopied, setAdminLinkCopied] = useState(false);
+
+    const isAdmin = !!adminToken;
+    const { locked } = discussionState;
 
     const shareUrl = typeof window !== 'undefined' ? window.location.href : '';
+    const adminUrl = typeof window !== 'undefined' && adminToken
+        ? `${window.location.origin}${window.location.pathname}?admin=${adminToken}`
+        : '';
 
     const handleCopyLink = async () => {
         try {
@@ -83,9 +93,69 @@ const DiscussionPage = () => {
         setPseudonym(identity.pseudonym);
     }, []);
 
+    // Adopt the moderator token for this topic: an ?admin=<token> URL param
+    // (shared admin link) takes precedence and is then persisted and stripped
+    // from the URL; otherwise fall back to a previously stored token.
+    useEffect(() => {
+        const storageKey = `convora_admin_${topic}`;
+        try {
+            const params = new URLSearchParams(window.location.search);
+            const fromUrl = params.get('admin');
+            if (fromUrl) {
+                localStorage.setItem(storageKey, fromUrl);
+                setAdminToken(fromUrl);
+                params.delete('admin');
+                const query = params.toString();
+                window.history.replaceState({}, '', `${window.location.pathname}${query ? `?${query}` : ''}`);
+                return;
+            }
+            setAdminToken(localStorage.getItem(storageKey));
+        } catch (e) {
+            console.warn('Failed to read admin token:', e);
+        }
+    }, [topic]);
+
     const handleRegeneratePseudonym = () => {
         const updated = regeneratePseudonym();
         setPseudonym(updated.pseudonym);
+    };
+
+    const handleClaimModerator = () => {
+        socket.emit('claimModerator', topic, (resp) => {
+            if (resp && resp.success) {
+                try {
+                    localStorage.setItem(`convora_admin_${topic}`, resp.token);
+                } catch (e) {
+                    console.warn('Failed to store admin token:', e);
+                }
+                setAdminToken(resp.token);
+            } else {
+                setError('This discussion already has a moderator.');
+            }
+        });
+    };
+
+    const handleToggleLock = () => {
+        socket.emit('setLocked', topic, !locked, adminToken);
+    };
+
+    const handleDeleteQuestion = (questionId) => {
+        socket.emit('deleteQuestion', topic, questionId, adminToken);
+    };
+
+    const handleTogglePin = (questionId, pinned) => {
+        socket.emit('setPinned', topic, questionId, !pinned, adminToken);
+    };
+
+    const handleCopyAdminLink = async () => {
+        try {
+            await navigator.clipboard.writeText(adminUrl);
+            setAdminLinkCopied(true);
+            setTimeout(() => setAdminLinkCopied(false), 2000);
+        } catch (err) {
+            console.error('Failed to copy admin link:', err);
+            setError('Could not copy the moderator link.');
+        }
     };
 
     const handleDuplicateDiscussion = async () => {
@@ -156,9 +226,13 @@ const DiscussionPage = () => {
         socket.emit('joinDiscussion', topic);
         socket.on('questions', handleQuestionsUpdate);
         socket.on('presence', setPresence);
+        socket.on('discussionState', setDiscussionState);
+        socket.on('similarQuestion', setSimilarPrompt);
         return () => {
             socket.off('questions', handleQuestionsUpdate);
             socket.off('presence', setPresence);
+            socket.off('discussionState', setDiscussionState);
+            socket.off('similarQuestion', setSimilarPrompt);
         };
     }, [topic, handleQuestionsUpdate]);
 
@@ -192,9 +266,15 @@ const DiscussionPage = () => {
         }
 
         console.log('Adding question:', question);
+        submitQuestion(question, false);
+    };
 
+    // Emits a question to the server. When force is false the server may reply
+    // with a 'similarQuestion' event instead of adding it; when true it adds
+    // regardless of near-duplicates.
+    const submitQuestion = (question, force) => {
         try {
-            socket.emit('addQuestion', topic, question);
+            socket.emit('addQuestion', topic, question, force);
 
             // Reset form
             setNewQuestion('');
@@ -206,6 +286,13 @@ const DiscussionPage = () => {
         } catch (error) {
             console.error('Error emitting addQuestion event:', error);
             setError('Failed to add question. Please try again.');
+        }
+    };
+
+    const handlePostAnyway = () => {
+        if (similarPrompt) {
+            submitQuestion(similarPrompt.question, true);
+            setSimilarPrompt(null);
         }
     };
 
@@ -274,24 +361,26 @@ const DiscussionPage = () => {
                 return (
                     <div>
                         <AgreementResults question={question} />
-                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                            {Object.values(VoteOptions).map((option) => (
-                                <div key={option} className="flex items-center justify-between bg-gray-100 p-3 rounded-md">
-                                    <span className="font-medium">
-                                        {option}: {question.votes ? question.votes.filter(v => v.value === option).length : 0}
-                                    </span>
-                                    <button
-                                        onClick={() => handleVote(question.id, option)}
-                                        className={`px-4 py-2 rounded-md transition duration-300 ${userVote && userVote.value === option
-                                            ? 'bg-primary text-white hover:bg-opacity-90'
-                                            : 'bg-secondary text-white hover:bg-opacity-90'
-                                            }`}
-                                    >
-                                        {userVote && userVote.value === option ? 'Undo Vote' : 'Vote'}
-                                    </button>
-                                </div>
-                            ))}
-                        </div>
+                        {!locked && (
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                {Object.values(VoteOptions).map((option) => (
+                                    <div key={option} className="flex items-center justify-between bg-gray-100 p-3 rounded-md">
+                                        <span className="font-medium">
+                                            {option}: {question.votes ? question.votes.filter(v => v.value === option).length : 0}
+                                        </span>
+                                        <button
+                                            onClick={() => handleVote(question.id, option)}
+                                            className={`px-4 py-2 rounded-md transition duration-300 ${userVote && userVote.value === option
+                                                ? 'bg-primary text-white hover:bg-opacity-90'
+                                                : 'bg-secondary text-white hover:bg-opacity-90'
+                                                }`}
+                                        >
+                                            {userVote && userVote.value === option ? 'Undo Vote' : 'Vote'}
+                                        </button>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
                     </div>
                 );
             case QuestionTypes.NUMERICAL: {
@@ -310,30 +399,34 @@ const DiscussionPage = () => {
                 return (
                     <div className="mt-4">
                         <NumericalResults question={question} minValue={minValue} maxValue={maxValue} />
-                        <input
-                            type="range"
-                            min={minValue}
-                            max={maxValue}
-                            value={sliderValue}
-                            className="w-full"
-                            onChange={(e) => handleSliderChange(question.id, parseInt(e.target.value))}
-                        />
-                        <div className="flex justify-between mt-2">
-                            <span>{minValue}</span>
-                            <span>{sliderValue}</span>
-                            <span>{maxValue}</span>
-                        </div>
-                        <button
-                            onClick={() => handleVote(question.id, sliderValue)}
-                            className={`mt-4 px-4 py-2 rounded-md transition duration-300 ${userVote ? 'bg-primary text-white hover:bg-opacity-90' : 'bg-secondary text-white hover:bg-opacity-90'}`}
-                        >
-                            {userVote ? 'Update Vote' : 'Submit'}
-                        </button>
+                        {!locked && (
+                            <>
+                                <input
+                                    type="range"
+                                    min={minValue}
+                                    max={maxValue}
+                                    value={sliderValue}
+                                    className="w-full"
+                                    onChange={(e) => handleSliderChange(question.id, parseInt(e.target.value))}
+                                />
+                                <div className="flex justify-between mt-2">
+                                    <span>{minValue}</span>
+                                    <span>{sliderValue}</span>
+                                    <span>{maxValue}</span>
+                                </div>
+                                <button
+                                    onClick={() => handleVote(question.id, sliderValue)}
+                                    className={`mt-4 px-4 py-2 rounded-md transition duration-300 ${userVote ? 'bg-primary text-white hover:bg-opacity-90' : 'bg-secondary text-white hover:bg-opacity-90'}`}
+                                >
+                                    {userVote ? 'Update Vote' : 'Submit'}
+                                </button>
+                            </>
+                        )}
                     </div>
                 );
             }
             case QuestionTypes.OPEN_ENDED: {
-                return <OpenEndedQuestion question={question} userVote={userVote} handleVote={handleVote} userId={userId} handleResponseVote={handleResponseVote} />;
+                return <OpenEndedQuestion question={question} userVote={userVote} handleVote={handleVote} userId={userId} handleResponseVote={handleResponseVote} locked={locked} />;
             }
 
             default:
@@ -343,6 +436,11 @@ const DiscussionPage = () => {
     };
 
     const sortedAndFilteredQuestions = filterQuestions(sortQuestions(questions));
+    // Pinned questions float to the top, preserving the chosen sort within each
+    // group (Array.prototype.sort is stable).
+    const orderedQuestions = [...sortedAndFilteredQuestions].sort(
+        (a, b) => (b.pinned ? 1 : 0) - (a.pinned ? 1 : 0)
+    );
 
     return (
         <div className="max-w-4xl mx-auto mt-10 px-4">
@@ -447,6 +545,77 @@ const DiscussionPage = () => {
                     </div>
                 </div>
             )}
+
+            {/* Moderator bar */}
+            <div className="mb-6">
+                {isAdmin ? (
+                    <div className="flex flex-wrap items-center gap-3 bg-indigo-50 border border-indigo-100 rounded-md p-3 text-sm">
+                        <span className="font-semibold text-indigo-800">You&apos;re the moderator</span>
+                        <button
+                            onClick={handleToggleLock}
+                            className="px-3 py-1 rounded bg-white border border-indigo-300 text-indigo-700 hover:bg-indigo-100"
+                        >
+                            {locked ? 'Unlock discussion' : 'Lock discussion'}
+                        </button>
+                        <button
+                            onClick={handleCopyAdminLink}
+                            className="px-3 py-1 rounded bg-white border border-indigo-300 text-indigo-700 hover:bg-indigo-100"
+                            title="Anyone with this link becomes a moderator"
+                        >
+                            {adminLinkCopied ? 'Link copied!' : 'Copy moderator link'}
+                        </button>
+                    </div>
+                ) : !discussionState.hasModerator ? (
+                    <button
+                        onClick={handleClaimModerator}
+                        className="text-sm text-gray-600 underline hover:text-gray-800"
+                    >
+                        Become moderator
+                    </button>
+                ) : null}
+            </div>
+
+            {/* Locked banner */}
+            {locked && (
+                <div className="mb-6 bg-amber-50 border border-amber-200 text-amber-800 rounded-md p-3 text-center">
+                    🔒 This discussion is locked. Voting and new statements are closed.
+                </div>
+            )}
+
+            {/* Near-duplicate prompt */}
+            {similarPrompt && (
+                <div
+                    className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full flex items-center justify-center"
+                    onClick={() => setSimilarPrompt(null)}
+                >
+                    <div className="bg-white p-6 rounded-lg shadow-xl max-w-md" onClick={(e) => e.stopPropagation()}>
+                        <h2 className="text-xl font-bold mb-3">A similar statement already exists</h2>
+                        <p className="text-sm text-gray-600 mb-2">Someone already posted:</p>
+                        <blockquote className="border-l-4 border-primary pl-3 italic text-gray-800 mb-4">
+                            {similarPrompt.candidate}
+                        </blockquote>
+                        <p className="text-sm text-gray-600 mb-4">
+                            Consider voting on the existing one to keep the discussion focused — or post yours anyway if it&apos;s meaningfully different.
+                        </p>
+                        <div className="flex justify-end gap-2">
+                            <button
+                                onClick={() => setSimilarPrompt(null)}
+                                className="px-4 py-2 bg-primary text-white rounded hover:bg-opacity-90"
+                            >
+                                Use existing
+                            </button>
+                            <button
+                                onClick={handlePostAnyway}
+                                className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300"
+                            >
+                                Post anyway
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {!locked && (
             <div className="bg-white shadow-lg rounded-lg p-6 mb-8">
                 <input
                     type="text"
@@ -495,8 +664,9 @@ const DiscussionPage = () => {
                 >
                     Add Question
                 </button>
-                {error && <div className="text-red-500 mt-2">{error}</div>}
             </div>
+            )}
+            {error && <div className="text-red-500 mb-4">{error}</div>}
             {/* Sorting and filtering controls */}
             <div className="mb-6 flex justify-between items-center">
                 <select
@@ -520,17 +690,38 @@ const DiscussionPage = () => {
             </div>
 
             {/* Questions list */}
-            {sortedAndFilteredQuestions.map((question) => (
+            {orderedQuestions.map((question) => (
                 <div key={question.id} className="bg-white shadow-lg rounded-lg p-6 mb-6">
-                    <h2 className="text-xl font-semibold mb-4">{question.text}</h2>
-                    <p className="mb-4">Type: {question.type}</p>
+                    <div className="flex justify-between items-start mb-4">
+                        <h2 className="text-xl font-semibold">
+                            {question.pinned && <span className="mr-1" title="Pinned">📌</span>}
+                            {question.text}
+                        </h2>
+                        {isAdmin && (
+                            <div className="flex gap-2 ml-4 shrink-0">
+                                <button
+                                    onClick={() => handleTogglePin(question.id, question.pinned)}
+                                    className="text-xs px-2 py-1 rounded border border-gray-300 text-gray-600 hover:bg-gray-100"
+                                >
+                                    {question.pinned ? 'Unpin' : 'Pin'}
+                                </button>
+                                <button
+                                    onClick={() => handleDeleteQuestion(question.id)}
+                                    className="text-xs px-2 py-1 rounded border border-red-300 text-red-600 hover:bg-red-50"
+                                >
+                                    Delete
+                                </button>
+                            </div>
+                        )}
+                    </div>
+                    <p className="mb-4 text-sm text-gray-500">Type: {question.type}</p>
                     {renderVotingMechanism(question)}
                 </div>
             ))}
         </div>
     );
 };
-const OpenEndedQuestion = ({ question, userVote, handleVote, userId, handleResponseVote }) => {
+const OpenEndedQuestion = ({ question, userVote, handleVote, userId, handleResponseVote, locked }) => {
     const [response, setResponse] = useState(userVote ? userVote.value : '');
 
     useEffect(() => {
@@ -544,22 +735,26 @@ const OpenEndedQuestion = ({ question, userVote, handleVote, userId, handleRespo
 
     return (
         <div>
-            <textarea
-                value={response}
-                onChange={(e) => setResponse(e.target.value)}
-                className="w-full p-2 border rounded mb-2"
-                rows="4"
-                placeholder="Enter your response here"
-            />
-            <button
-                onClick={() => {
-                    console.log('Submitting open-ended response:', response);
-                    handleVote(question.id, response);
-                }}
-                className="px-4 py-2 bg-primary text-white rounded hover:bg-opacity-90 transition duration-300 mb-4"
-            >
-                {userVote ? 'Update Response' : 'Submit Response'}
-            </button>
+            {!locked && (
+                <>
+                    <textarea
+                        value={response}
+                        onChange={(e) => setResponse(e.target.value)}
+                        className="w-full p-2 border rounded mb-2"
+                        rows="4"
+                        placeholder="Enter your response here"
+                    />
+                    <button
+                        onClick={() => {
+                            console.log('Submitting open-ended response:', response);
+                            handleVote(question.id, response);
+                        }}
+                        className="px-4 py-2 bg-primary text-white rounded hover:bg-opacity-90 transition duration-300 mb-4"
+                    >
+                        {userVote ? 'Update Response' : 'Submit Response'}
+                    </button>
+                </>
+            )}
 
             {question.votes && question.votes.length > 0 && (
                 <div className="mt-4">
@@ -574,12 +769,12 @@ const OpenEndedQuestion = ({ question, userVote, handleVote, userId, handleRespo
                                 <li key={vote.id} className="bg-gray-50 rounded-md p-3 flex items-start gap-3">
                                     <button
                                         onClick={() => handleResponseVote(vote.id)}
-                                        disabled={isOwnResponse}
+                                        disabled={isOwnResponse || locked}
                                         title={isOwnResponse ? "You can't upvote your own response" : 'Upvote'}
                                         className={`flex flex-col items-center justify-center px-2 py-1 rounded-md border transition duration-200 ${hasUpvoted
                                             ? 'bg-primary text-white border-primary'
                                             : 'bg-white text-gray-600 border-gray-300 hover:border-primary'
-                                            } ${isOwnResponse ? 'opacity-40 cursor-not-allowed' : ''}`}
+                                            } ${(isOwnResponse || locked) ? 'opacity-40 cursor-not-allowed' : ''}`}
                                     >
                                         <span className="leading-none">▲</span>
                                         <span className="text-xs font-semibold">{upvotes}</span>
@@ -618,7 +813,8 @@ OpenEndedQuestion.propTypes = {
     }),
     handleVote: PropTypes.func.isRequired,
     userId: PropTypes.string,
-    handleResponseVote: PropTypes.func.isRequired
+    handleResponseVote: PropTypes.func.isRequired,
+    locked: PropTypes.bool
 };
 
 // Stacked divergence bar + summary for an Agreement question. Shows at a glance

--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import io from 'socket.io-client';
+import { QRCodeSVG } from 'qrcode.react';
 import { getIdentity, regeneratePseudonym } from './identity';
 
 const VERSION = '0.1.8';
@@ -59,6 +60,22 @@ const DiscussionPage = () => {
     const [error, setError] = useState(null);
     const [newTopicName, setNewTopicName] = useState('');
     const [showDuplicateModal, setShowDuplicateModal] = useState(false);
+    const [showShareModal, setShowShareModal] = useState(false);
+    const [presence, setPresence] = useState(0);
+    const [copied, setCopied] = useState(false);
+
+    const shareUrl = typeof window !== 'undefined' ? window.location.href : '';
+
+    const handleCopyLink = async () => {
+        try {
+            await navigator.clipboard.writeText(shareUrl);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        } catch (err) {
+            console.error('Failed to copy link:', err);
+            setError('Could not copy the link. You can select and copy it manually.');
+        }
+    };
 
     useEffect(() => {
         const identity = getIdentity();
@@ -138,8 +155,10 @@ const DiscussionPage = () => {
         console.log('Current topic:', topic);
         socket.emit('joinDiscussion', topic);
         socket.on('questions', handleQuestionsUpdate);
+        socket.on('presence', setPresence);
         return () => {
             socket.off('questions', handleQuestionsUpdate);
+            socket.off('presence', setPresence);
         };
     }, [topic, handleQuestionsUpdate]);
 
@@ -198,6 +217,10 @@ const DiscussionPage = () => {
 
     const handleSliderChange = (questionId, value) => {
         setSliderValues(prev => ({ ...prev, [questionId]: value }));
+    };
+
+    const handleResponseVote = (responseId) => {
+        socket.emit('toggleResponseVote', topic, responseId, userId);
     };
 
     const sortQuestions = (questions) => {
@@ -310,7 +333,7 @@ const DiscussionPage = () => {
                 );
             }
             case QuestionTypes.OPEN_ENDED: {
-                return <OpenEndedQuestion question={question} userVote={userVote} handleVote={handleVote} />;
+                return <OpenEndedQuestion question={question} userVote={userVote} handleVote={handleVote} userId={userId} handleResponseVote={handleResponseVote} />;
             }
 
             default:
@@ -325,7 +348,7 @@ const DiscussionPage = () => {
         <div className="max-w-4xl mx-auto mt-10 px-4">
             <h1 className="text-4xl font-bold mb-2 text-center text-gray-800">Discussion: {topic}</h1>
 
-            {/* Participant identity */}
+            {/* Participant identity + live presence */}
             <div className="mb-8 text-center text-sm text-gray-600">
                 You are <span className="font-semibold text-gray-800">{pseudonym || '…'}</span>
                 <button
@@ -335,15 +358,28 @@ const DiscussionPage = () => {
                 >
                     (change)
                 </button>
+                <span className="mx-2 text-gray-300">·</span>
+                <span className="inline-flex items-center">
+                    <span className="inline-block w-2 h-2 rounded-full bg-green-500 mr-1.5" />
+                    {presence} {presence === 1 ? 'person' : 'people'} here now
+                </span>
             </div>
 
-            {/* Duplicate Discussion Button */}
-            <button
-                onClick={() => setShowDuplicateModal(true)}
-                className="mb-4 bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 transition duration-300"
-            >
-                Duplicate Discussion
-            </button>
+            {/* Discussion actions */}
+            <div className="mb-4 flex gap-2">
+                <button
+                    onClick={() => setShowShareModal(true)}
+                    className="bg-primary text-white py-2 px-4 rounded hover:bg-opacity-90 transition duration-300"
+                >
+                    Share
+                </button>
+                <button
+                    onClick={() => setShowDuplicateModal(true)}
+                    className="bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 transition duration-300"
+                >
+                    Duplicate Discussion
+                </button>
+            </div>
 
             {/* Duplicate Modal */}
             {showDuplicateModal && (
@@ -371,6 +407,43 @@ const DiscussionPage = () => {
                                 Duplicate
                             </button>
                         </div>
+                    </div>
+                </div>
+            )}
+
+            {/* Share Modal */}
+            {showShareModal && (
+                <div
+                    className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full flex items-center justify-center"
+                    onClick={() => setShowShareModal(false)}
+                >
+                    <div className="bg-white p-6 rounded-lg shadow-xl text-center" onClick={(e) => e.stopPropagation()}>
+                        <h2 className="text-xl font-bold mb-4">Share this discussion</h2>
+                        <div className="flex justify-center mb-4">
+                            <QRCodeSVG value={shareUrl} size={180} includeMargin />
+                        </div>
+                        <p className="text-sm text-gray-500 mb-2">Scan to join, or copy the link:</p>
+                        <div className="flex items-center gap-2 mb-4">
+                            <input
+                                type="text"
+                                readOnly
+                                value={shareUrl}
+                                onFocus={(e) => e.target.select()}
+                                className="flex-1 p-2 border rounded text-sm bg-gray-50"
+                            />
+                            <button
+                                onClick={handleCopyLink}
+                                className="px-4 py-2 bg-primary text-white rounded hover:bg-opacity-90 whitespace-nowrap"
+                            >
+                                {copied ? 'Copied!' : 'Copy'}
+                            </button>
+                        </div>
+                        <button
+                            onClick={() => setShowShareModal(false)}
+                            className="px-4 py-2 bg-gray-300 rounded hover:bg-gray-400"
+                        >
+                            Close
+                        </button>
                     </div>
                 </div>
             )}
@@ -457,12 +530,17 @@ const DiscussionPage = () => {
         </div>
     );
 };
-const OpenEndedQuestion = ({ question, userVote, handleVote }) => {
+const OpenEndedQuestion = ({ question, userVote, handleVote, userId, handleResponseVote }) => {
     const [response, setResponse] = useState(userVote ? userVote.value : '');
 
     useEffect(() => {
         setResponse(userVote ? userVote.value : '');
     }, [userVote]);
+
+    // Most-upvoted responses first; ties keep submission order (vote id).
+    const sortedResponses = [...(question.votes || [])].sort(
+        (a, b) => (b.upvotes || 0) - (a.upvotes || 0) || a.id - b.id
+    );
 
     return (
         <div>
@@ -487,15 +565,32 @@ const OpenEndedQuestion = ({ question, userVote, handleVote }) => {
                 <div className="mt-4">
                     <h3 className="font-semibold mb-2">All Responses:</h3>
                     <ul className="space-y-2">
-                        {question.votes.map((vote, index) => {
+                        {sortedResponses.map((vote) => {
                             const isYou = vote.userId === userVote?.userId;
+                            const upvotes = vote.upvotes || 0;
+                            const hasUpvoted = Array.isArray(vote.upvoters) && vote.upvoters.includes(userId);
+                            const isOwnResponse = vote.userId === userId;
                             return (
-                                <li key={index} className="bg-gray-50 rounded-md p-3">
-                                    <div className="text-xs font-semibold text-gray-500 mb-1">
-                                        {vote.pseudonym || 'Anonymous'}
-                                        {isYou && ' (you)'}
+                                <li key={vote.id} className="bg-gray-50 rounded-md p-3 flex items-start gap-3">
+                                    <button
+                                        onClick={() => handleResponseVote(vote.id)}
+                                        disabled={isOwnResponse}
+                                        title={isOwnResponse ? "You can't upvote your own response" : 'Upvote'}
+                                        className={`flex flex-col items-center justify-center px-2 py-1 rounded-md border transition duration-200 ${hasUpvoted
+                                            ? 'bg-primary text-white border-primary'
+                                            : 'bg-white text-gray-600 border-gray-300 hover:border-primary'
+                                            } ${isOwnResponse ? 'opacity-40 cursor-not-allowed' : ''}`}
+                                    >
+                                        <span className="leading-none">▲</span>
+                                        <span className="text-xs font-semibold">{upvotes}</span>
+                                    </button>
+                                    <div className="flex-1">
+                                        <div className="text-xs font-semibold text-gray-500 mb-1">
+                                            {vote.pseudonym || 'Anonymous'}
+                                            {isYou && ' (you)'}
+                                        </div>
+                                        <div className="text-gray-800 whitespace-pre-wrap">{vote.value}</div>
                                     </div>
-                                    <div className="text-gray-800 whitespace-pre-wrap">{vote.value}</div>
                                 </li>
                             );
                         })}
@@ -508,18 +603,22 @@ const OpenEndedQuestion = ({ question, userVote, handleVote }) => {
 
 OpenEndedQuestion.propTypes = {
     question: PropTypes.shape({
-        id: PropTypes.string.isRequired,
+        id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
         votes: PropTypes.arrayOf(PropTypes.shape({
             userId: PropTypes.string.isRequired,
             value: PropTypes.string.isRequired,
-            pseudonym: PropTypes.string
+            pseudonym: PropTypes.string,
+            upvotes: PropTypes.number,
+            upvoters: PropTypes.array
         }))
     }).isRequired,
     userVote: PropTypes.shape({
         userId: PropTypes.string.isRequired,
         value: PropTypes.string
     }),
-    handleVote: PropTypes.func.isRequired
+    handleVote: PropTypes.func.isRequired,
+    userId: PropTypes.string,
+    handleResponseVote: PropTypes.func.isRequired
 };
 
 // Stacked divergence bar + summary for an Agreement question. Shows at a glance

--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -205,20 +205,27 @@ const DiscussionPage = () => {
     const handleQuestionsUpdate = useCallback((updatedQuestions) => {
         console.log('Received updated questions:', updatedQuestions);
         setQuestions(prevQuestions => {
-            const questionMap = new Map(prevQuestions.map(q => [q.id, q]));
+            // The server always emits a full snapshot of the discussion's
+            // questions, so we rebuild the list from the incoming set. Building
+            // a fresh map (rather than merging into the previous one) prunes any
+            // question the moderator deleted — ids absent from the snapshot drop
+            // out instead of lingering as visible/votable stale entries.
+            const prevMap = new Map(prevQuestions.map(q => [q.id, q]));
+            const nextMap = new Map();
             updatedQuestions.forEach(q => {
-                if (questionMap.has(q.id)) {
+                const prev = prevMap.get(q.id);
+                if (prev) {
                     // Merge the new question data with the existing data,
                     // ensuring we keep the votes array and handle numerical values
-                    questionMap.set(q.id, {
-                        ...questionMap.get(q.id),
+                    nextMap.set(q.id, {
+                        ...prev,
                         ...q,
                         minValue: q.type === QuestionTypes.NUMERICAL ? parseInt(q.minValue) : undefined,
                         maxValue: q.type === QuestionTypes.NUMERICAL ? parseInt(q.maxValue) : undefined,
-                        votes: q.votes || questionMap.get(q.id).votes || []
+                        votes: q.votes || prev.votes || []
                     });
                 } else {
-                    questionMap.set(q.id, {
+                    nextMap.set(q.id, {
                         ...q,
                         timestamp: Date.now(),
                         votes: q.votes || [],
@@ -226,9 +233,9 @@ const DiscussionPage = () => {
                         maxValue: q.type === QuestionTypes.NUMERICAL ? parseInt(q.maxValue) : undefined
                     });
                 }
-                console.log('Updated question:', questionMap.get(q.id));
+                console.log('Updated question:', nextMap.get(q.id));
             });
-            return Array.from(questionMap.values());
+            return Array.from(nextMap.values());
         });
     }, []);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
                 "pg": "^8.12.0",
                 "postcss": "^8.4.38",
                 "prop-types": "^15.8.1",
+                "qrcode.react": "^3.1.0",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "react-router-dom": "^6.26.0",
@@ -4609,6 +4610,15 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/qrcode.react": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-3.1.0.tgz",
+            "integrity": "sha512-oyF+Urr3oAMUG/OiOuONL3HXM+53wvuH3mtIWQrYmsXoAq0DkvZp2RYUWFSMFtbdOpuS++9v+WAkzNVkMlNW6Q==",
+            "license": "ISC",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
             }
         },
         "node_modules/qs": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "pg": "^8.12.0",
         "postcss": "^8.4.38",
         "prop-types": "^15.8.1",
+        "qrcode.react": "^3.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.26.0",

--- a/server.js
+++ b/server.js
@@ -93,6 +93,18 @@ io.on('connection', (socket) => {
     }
   });
 
+  socket.on('leaveDiscussion', (topic) => {
+    // The client unmounted its discussion page; drop it from the room and
+    // recompute presence so the counter doesn't over-report lingering viewers.
+    const roomToLeave = topic || socket.data.topic;
+    if (!roomToLeave) return;
+    socket.leave(roomToLeave);
+    if (socket.data.topic === roomToLeave) {
+      socket.data.topic = null;
+    }
+    emitPresence(roomToLeave);
+  });
+
   socket.on('addQuestion', async (topic, question) => {
     console.log('Received addQuestion event');
     console.log('topic:', topic);
@@ -374,6 +386,19 @@ async function addVote(questionId, vote, userId, pseudonym) {
 // Toggle a user's upvote on an open-ended response. Adds the upvote if absent,
 // removes it if already present.
 async function toggleResponseVote(responseId, userId) {
+  // Reject self-upvotes: the UI disables the button for your own response, but
+  // the event can still be emitted from the console, so enforce it server-side.
+  const ownerResult = await pool.query(
+    'SELECT user_id FROM votes WHERE id = $1',
+    [responseId]
+  );
+  if (ownerResult.rows.length === 0) {
+    return;
+  }
+  if (ownerResult.rows[0].user_id === userId) {
+    console.log('Ignoring self-upvote on response', responseId);
+    return;
+  }
   const deleteResult = await pool.query(
     'DELETE FROM response_votes WHERE response_id = $1 AND user_id = $2',
     [responseId, userId]

--- a/server.js
+++ b/server.js
@@ -60,12 +60,30 @@ function parseOptions(options) {
 app.use(bodyParser.json());
 app.use(express.static(path.join(__dirname, 'dist')));
 
+// Emit the number of clients currently in a discussion room to everyone there.
+function emitPresence(topic) {
+  if (!topic) return;
+  const count = io.sockets.adapter.rooms.get(topic)?.size || 0;
+  io.to(topic).emit('presence', count);
+}
+
 // WebSocket handlers
 io.on('connection', (socket) => {
   console.log('New client connected');
 
   socket.on('joinDiscussion', async (topic) => {
+    // If this socket was viewing another discussion, leave it so presence
+    // counts stay accurate as the user navigates within the SPA.
+    const previousTopic = socket.data.topic;
+    if (previousTopic && previousTopic !== topic) {
+      socket.leave(previousTopic);
+      emitPresence(previousTopic);
+    }
+
     socket.join(topic);
+    socket.data.topic = topic;
+    emitPresence(topic);
+
     try {
       const questions = await getQuestions(topic);
       socket.emit('questions', questions);
@@ -103,8 +121,22 @@ io.on('connection', (socket) => {
     }
   });
 
+  socket.on('toggleResponseVote', async (topic, responseId, userId) => {
+    try {
+      await toggleResponseVote(responseId, userId);
+      const questions = await getQuestions(topic);
+      io.to(topic).emit('questions', questions);
+    } catch (error) {
+      console.error('Error toggling response vote:', error);
+      socket.emit('error', { message: 'Failed to upvote response' });
+    }
+  });
+
   socket.on('disconnect', () => {
     console.log('Client disconnected');
+    // The socket has already left its rooms by now, so the count reflects the
+    // remaining participants.
+    emitPresence(socket.data.topic);
   });
 });
 
@@ -161,7 +193,9 @@ async function getQuestions(topic) {
           'id', v.id,
           'value', v.value,
           'userId', v.user_id,
-          'pseudonym', v.pseudonym
+          'pseudonym', v.pseudonym,
+          'upvotes', (SELECT COUNT(*) FROM response_votes rv WHERE rv.response_id = v.id),
+          'upvoters', (SELECT COALESCE(json_agg(rv.user_id), '[]'::json) FROM response_votes rv WHERE rv.response_id = v.id)
         ) ORDER BY v.id
       ) FILTER (WHERE v.id IS NOT NULL), '[]'::json) as votes
     FROM questions q
@@ -265,6 +299,25 @@ async function migrateAddPseudonymColumn() {
 }
 migrateAddPseudonymColumn().catch(console.error);
 
+// Table for upvotes on individual open-ended responses. One row per
+// (response, user); a response is identified by its votes.id. Idempotent.
+async function migrateResponseVotesTable() {
+  try {
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS response_votes (
+        id SERIAL PRIMARY KEY,
+        response_id INTEGER NOT NULL REFERENCES votes(id) ON DELETE CASCADE,
+        user_id TEXT NOT NULL,
+        UNIQUE (response_id, user_id)
+      )
+    `);
+    console.log('response_votes table migration completed');
+  } catch (e) {
+    console.error('Error creating response_votes table:', e);
+  }
+}
+migrateResponseVotesTable().catch(console.error);
+
 async function addVote(questionId, vote, userId, pseudonym) {
   console.log('Adding vote:', questionId, vote, userId, pseudonym);
   const client = await pool.connect();
@@ -315,6 +368,21 @@ async function addVote(questionId, vote, userId, pseudonym) {
     throw e;
   } finally {
     client.release();
+  }
+}
+
+// Toggle a user's upvote on an open-ended response. Adds the upvote if absent,
+// removes it if already present.
+async function toggleResponseVote(responseId, userId) {
+  const deleteResult = await pool.query(
+    'DELETE FROM response_votes WHERE response_id = $1 AND user_id = $2',
+    [responseId, userId]
+  );
+  if (deleteResult.rowCount === 0) {
+    await pool.query(
+      'INSERT INTO response_votes (response_id, user_id) VALUES ($1, $2) ON CONFLICT DO NOTHING',
+      [responseId, userId]
+    );
   }
 }
 

--- a/server.js
+++ b/server.js
@@ -474,16 +474,21 @@ async function claimModerator(topic) {
     const existing = await client.query('SELECT admin_token FROM discussions WHERE topic = $1', [topic]);
 
     let result;
-    if (existing.rows.length === 0) {
+    if (existing.rows.some(row => row.admin_token)) {
+      // Already claimed. Inspect every row for the topic, not just the first:
+      // duplicate-topic rows can exist (no unique constraint), so a later row
+      // holding a token must block a fresh claim even if rows[0] is unclaimed.
+      result = null;
+    } else if (existing.rows.length === 0) {
       const inserted = await client.query(
         'INSERT INTO discussions (topic, admin_token) VALUES ($1, $2) RETURNING admin_token',
         [topic, token]
       );
       result = inserted.rows[0].admin_token;
-    } else if (existing.rows[0].admin_token) {
-      result = null; // already has a moderator
     } else {
-      // Claim the existing, unclaimed discussion.
+      // No row is claimed yet. Stamp the same token on all unclaimed rows for
+      // the topic so it resolves to a single moderator regardless of which
+      // duplicate row a later SELECT happens to read.
       const updated = await client.query(
         'UPDATE discussions SET admin_token = $1 WHERE topic = $2 AND admin_token IS NULL RETURNING admin_token',
         [token, topic]

--- a/server.js
+++ b/server.js
@@ -156,7 +156,15 @@ io.on('connection', (socket) => {
 
   socket.on('vote', async (topic, questionId, vote, userId, pseudonym) => {
     try {
-      if (await isDiscussionLocked(topic)) {
+      // Verify the question actually belongs to this topic AND that the topic is
+      // not locked. Without this, a client could bypass a locked discussion by
+      // sending the locked question's id under some other (unlocked) topic.
+      const target = await getQuestionForTopic(topic, questionId);
+      if (!target) {
+        socket.emit('error', { message: 'Invalid question for this discussion.' });
+        return;
+      }
+      if (target.locked) {
         socket.emit('error', { message: 'Voting is closed for this discussion.' });
         return;
       }
@@ -192,8 +200,16 @@ io.on('connection', (socket) => {
         socket.emit('error', { message: 'Not authorized to moderate this discussion.' });
         return;
       }
-      // Remove votes first (response_votes cascade) to satisfy FK constraints.
-      await pool.query('DELETE FROM votes WHERE question_id = $1', [questionId]);
+      // Scope the vote delete through the question's discussion so a moderator of
+      // one discussion can never wipe another discussion's votes by passing a
+      // foreign questionId. Delete votes first to satisfy the FK constraint, then
+      // the question itself (also constrained by discussion_id).
+      await pool.query(
+        `DELETE FROM votes
+         WHERE question_id = $1
+           AND question_id IN (SELECT id FROM questions WHERE discussion_id = $2)`,
+        [questionId, discussionId]
+      );
       await pool.query('DELETE FROM questions WHERE id = $1 AND discussion_id = $2', [questionId, discussionId]);
       io.to(topic).emit('questions', await getQuestions(topic));
     } catch (error) {
@@ -471,6 +487,22 @@ async function claimModerator(topic) {
 async function isDiscussionLocked(topic) {
   const result = await pool.query('SELECT locked FROM discussions WHERE topic = $1', [topic]);
   return result.rows.length > 0 ? result.rows[0].locked === true : false;
+}
+
+// Confirm a question belongs to the given topic and report whether that
+// discussion is locked. Returns null when the question does not belong to the
+// topic, so callers can reject mismatched/forged questionIds. The join on
+// topic means a question id from a different discussion never matches.
+async function getQuestionForTopic(topic, questionId) {
+  const result = await pool.query(
+    `SELECT q.id, d.locked
+     FROM questions q
+     JOIN discussions d ON q.discussion_id = d.id
+     WHERE d.topic = $1 AND q.id = $2`,
+    [topic, questionId]
+  );
+  if (result.rows.length === 0) return null;
+  return { id: result.rows[0].id, locked: result.rows[0].locked === true };
 }
 
 // Return the text of the most similar existing statement in the discussion if

--- a/server.js
+++ b/server.js
@@ -457,30 +457,48 @@ async function verifyAdmin(topic, token) {
 
 // First-come moderator claim: assigns a fresh admin token only if the
 // discussion has none yet. Returns the token, or null if already claimed.
-// (discussions.topic has no unique constraint in this schema, so we avoid
-// ON CONFLICT and use SELECT/INSERT like the rest of the app.)
+// discussions.topic has no unique constraint in this schema (the rest of the
+// app tolerates duplicate-topic rows), so we can't lean on ON CONFLICT. To keep
+// the first-come guarantee even for a brand-new topic — where two concurrent
+// claims could otherwise both see no row and both INSERT, producing duplicate
+// rows each with a valid token — we serialize claims for the same topic with a
+// transaction-scoped advisory lock. hashtext() maps the topic to the bigint the
+// lock API expects; the lock releases automatically on COMMIT/ROLLBACK.
 async function claimModerator(topic) {
   const token = crypto.randomBytes(16).toString('hex');
-  const existing = await pool.query('SELECT admin_token FROM discussions WHERE topic = $1', [topic]);
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [topic]);
 
-  if (existing.rows.length === 0) {
-    const inserted = await pool.query(
-      'INSERT INTO discussions (topic, admin_token) VALUES ($1, $2) RETURNING admin_token',
-      [topic, token]
-    );
-    return inserted.rows[0].admin_token;
+    const existing = await client.query('SELECT admin_token FROM discussions WHERE topic = $1', [topic]);
+
+    let result;
+    if (existing.rows.length === 0) {
+      const inserted = await client.query(
+        'INSERT INTO discussions (topic, admin_token) VALUES ($1, $2) RETURNING admin_token',
+        [topic, token]
+      );
+      result = inserted.rows[0].admin_token;
+    } else if (existing.rows[0].admin_token) {
+      result = null; // already has a moderator
+    } else {
+      // Claim the existing, unclaimed discussion.
+      const updated = await client.query(
+        'UPDATE discussions SET admin_token = $1 WHERE topic = $2 AND admin_token IS NULL RETURNING admin_token',
+        [token, topic]
+      );
+      result = updated.rows.length > 0 ? updated.rows[0].admin_token : null;
+    }
+
+    await client.query('COMMIT');
+    return result;
+  } catch (e) {
+    await client.query('ROLLBACK');
+    throw e;
+  } finally {
+    client.release();
   }
-
-  if (existing.rows[0].admin_token) {
-    return null; // already has a moderator
-  }
-
-  // Claim the existing, unclaimed discussion atomically (guards against a race).
-  const updated = await pool.query(
-    'UPDATE discussions SET admin_token = $1 WHERE topic = $2 AND admin_token IS NULL RETURNING admin_token',
-    [token, topic]
-  );
-  return updated.rows.length > 0 ? updated.rows[0].admin_token : null;
 }
 
 // Whether voting is currently closed for a discussion.

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const http = require('http');
 const socketIo = require('socket.io');
 const { Pool } = require('pg');
 const path = require('path');
+const crypto = require('crypto');
 const bodyParser = require('body-parser');
 const cors = require('cors');
 
@@ -67,6 +68,20 @@ function emitPresence(topic) {
   io.to(topic).emit('presence', count);
 }
 
+// Read the lock state and whether a moderator has been claimed.
+async function getDiscussionState(topic) {
+  const result = await pool.query(
+    'SELECT locked, admin_token IS NOT NULL AS has_moderator FROM discussions WHERE topic = $1',
+    [topic]
+  );
+  if (result.rows.length === 0) return { locked: false, hasModerator: false };
+  return { locked: result.rows[0].locked === true, hasModerator: result.rows[0].has_moderator === true };
+}
+
+async function emitDiscussionState(topic) {
+  io.to(topic).emit('discussionState', await getDiscussionState(topic));
+}
+
 // WebSocket handlers
 io.on('connection', (socket) => {
   console.log('New client connected');
@@ -87,18 +102,34 @@ io.on('connection', (socket) => {
     try {
       const questions = await getQuestions(topic);
       socket.emit('questions', questions);
+      socket.emit('discussionState', await getDiscussionState(topic));
     } catch (error) {
       console.error('Error getting questions:', error);
       socket.emit('error', { message: 'Failed to get questions' });
     }
   });
 
-  socket.on('addQuestion', async (topic, question) => {
+  socket.on('addQuestion', async (topic, question, force) => {
     console.log('Received addQuestion event');
     console.log('topic:', topic);
     console.log('question:', question);
 
     try {
+      if (await isDiscussionLocked(topic)) {
+        socket.emit('error', { message: 'This discussion is locked.' });
+        return;
+      }
+
+      // Surface a near-duplicate so the submitter can vote on the existing
+      // statement instead — unless they explicitly chose to post anyway.
+      if (!force) {
+        const similar = await findSimilarQuestion(topic, question.text);
+        if (similar) {
+          socket.emit('similarQuestion', { candidate: similar, question });
+          return;
+        }
+      }
+
       await addQuestion(topic, question);
       console.log('Question added successfully');
       const updatedQuestions = await getQuestions(topic);
@@ -112,12 +143,79 @@ io.on('connection', (socket) => {
 
   socket.on('vote', async (topic, questionId, vote, userId, pseudonym) => {
     try {
+      if (await isDiscussionLocked(topic)) {
+        socket.emit('error', { message: 'Voting is closed for this discussion.' });
+        return;
+      }
       await addVote(questionId, vote, userId, pseudonym);
       const questions = await getQuestions(topic);
       io.to(topic).emit('questions', questions);
     } catch (error) {
       console.error('Error handling vote:', error);
       socket.emit('error', { message: 'Failed to handle vote' });
+    }
+  });
+
+  // First-come moderator claim. Replies via ack callback with the admin token.
+  socket.on('claimModerator', async (topic, cb) => {
+    try {
+      const token = await claimModerator(topic);
+      if (token) {
+        if (typeof cb === 'function') cb({ success: true, token });
+        await emitDiscussionState(topic);
+      } else if (typeof cb === 'function') {
+        cb({ success: false, error: 'already_claimed' });
+      }
+    } catch (error) {
+      console.error('Error claiming moderator:', error);
+      if (typeof cb === 'function') cb({ success: false, error: 'server_error' });
+    }
+  });
+
+  socket.on('deleteQuestion', async (topic, questionId, token) => {
+    try {
+      const discussionId = await verifyAdmin(topic, token);
+      if (!discussionId) {
+        socket.emit('error', { message: 'Not authorized to moderate this discussion.' });
+        return;
+      }
+      // Remove votes first (response_votes cascade) to satisfy FK constraints.
+      await pool.query('DELETE FROM votes WHERE question_id = $1', [questionId]);
+      await pool.query('DELETE FROM questions WHERE id = $1 AND discussion_id = $2', [questionId, discussionId]);
+      io.to(topic).emit('questions', await getQuestions(topic));
+    } catch (error) {
+      console.error('Error deleting question:', error);
+      socket.emit('error', { message: 'Failed to delete question' });
+    }
+  });
+
+  socket.on('setLocked', async (topic, locked, token) => {
+    try {
+      const discussionId = await verifyAdmin(topic, token);
+      if (!discussionId) {
+        socket.emit('error', { message: 'Not authorized to moderate this discussion.' });
+        return;
+      }
+      await pool.query('UPDATE discussions SET locked = $1 WHERE id = $2', [!!locked, discussionId]);
+      await emitDiscussionState(topic);
+    } catch (error) {
+      console.error('Error setting lock state:', error);
+      socket.emit('error', { message: 'Failed to update discussion' });
+    }
+  });
+
+  socket.on('setPinned', async (topic, questionId, pinned, token) => {
+    try {
+      const discussionId = await verifyAdmin(topic, token);
+      if (!discussionId) {
+        socket.emit('error', { message: 'Not authorized to moderate this discussion.' });
+        return;
+      }
+      await pool.query('UPDATE questions SET pinned = $1 WHERE id = $2 AND discussion_id = $3', [!!pinned, questionId, discussionId]);
+      io.to(topic).emit('questions', await getQuestions(topic));
+    } catch (error) {
+      console.error('Error setting pin state:', error);
+      socket.emit('error', { message: 'Failed to update question' });
     }
   });
 
@@ -185,9 +283,10 @@ async function getQuestions(topic) {
       q.id, 
       q.text, 
       q.type, 
-      q.min_value, 
-      q.max_value, 
+      q.min_value,
+      q.max_value,
       q.options,
+      q.pinned,
       COALESCE(json_agg(
         json_build_object(
           'id', v.id,
@@ -200,10 +299,10 @@ async function getQuestions(topic) {
       ) FILTER (WHERE v.id IS NOT NULL), '[]'::json) as votes
     FROM questions q
     JOIN discussions d ON q.discussion_id = d.id
-    LEFT JOIN votes v ON q.id = v.question_id 
+    LEFT JOIN votes v ON q.id = v.question_id
     WHERE d.topic = $1
-    GROUP BY q.id 
-    ORDER BY q.id
+    GROUP BY q.id
+    ORDER BY q.pinned DESC, q.id
   `;
 
   const result = await pool.query(query, [topic]);
@@ -317,6 +416,90 @@ async function migrateResponseVotesTable() {
   }
 }
 migrateResponseVotesTable().catch(console.error);
+
+// Moderation columns: a per-discussion admin token, a discussion lock, and a
+// per-question pin flag. Plus the pg_trgm extension for near-duplicate
+// statement detection. All idempotent.
+async function migrateModerationAndDedup() {
+  try {
+    await pool.query('ALTER TABLE discussions ADD COLUMN IF NOT EXISTS admin_token TEXT');
+    await pool.query('ALTER TABLE discussions ADD COLUMN IF NOT EXISTS locked BOOLEAN NOT NULL DEFAULT FALSE');
+    await pool.query('ALTER TABLE questions ADD COLUMN IF NOT EXISTS pinned BOOLEAN NOT NULL DEFAULT FALSE');
+    await pool.query('CREATE EXTENSION IF NOT EXISTS pg_trgm');
+    console.log('Moderation + dedup migration completed');
+  } catch (e) {
+    console.error('Error in moderation/dedup migration:', e);
+  }
+}
+migrateModerationAndDedup().catch(console.error);
+
+// Verify that the supplied token is the discussion's admin token. Returns the
+// discussion id when valid, or null otherwise.
+async function verifyAdmin(topic, token) {
+  if (!token) return null;
+  const result = await pool.query(
+    'SELECT id FROM discussions WHERE topic = $1 AND admin_token = $2',
+    [topic, token]
+  );
+  return result.rows.length > 0 ? result.rows[0].id : null;
+}
+
+// First-come moderator claim: assigns a fresh admin token only if the
+// discussion has none yet. Returns the token, or null if already claimed.
+// (discussions.topic has no unique constraint in this schema, so we avoid
+// ON CONFLICT and use SELECT/INSERT like the rest of the app.)
+async function claimModerator(topic) {
+  const token = crypto.randomBytes(16).toString('hex');
+  const existing = await pool.query('SELECT admin_token FROM discussions WHERE topic = $1', [topic]);
+
+  if (existing.rows.length === 0) {
+    const inserted = await pool.query(
+      'INSERT INTO discussions (topic, admin_token) VALUES ($1, $2) RETURNING admin_token',
+      [topic, token]
+    );
+    return inserted.rows[0].admin_token;
+  }
+
+  if (existing.rows[0].admin_token) {
+    return null; // already has a moderator
+  }
+
+  // Claim the existing, unclaimed discussion atomically (guards against a race).
+  const updated = await pool.query(
+    'UPDATE discussions SET admin_token = $1 WHERE topic = $2 AND admin_token IS NULL RETURNING admin_token',
+    [token, topic]
+  );
+  return updated.rows.length > 0 ? updated.rows[0].admin_token : null;
+}
+
+// Whether voting is currently closed for a discussion.
+async function isDiscussionLocked(topic) {
+  const result = await pool.query('SELECT locked FROM discussions WHERE topic = $1', [topic]);
+  return result.rows.length > 0 ? result.rows[0].locked === true : false;
+}
+
+// Return the text of the most similar existing statement in the discussion if
+// it crosses the trigram-similarity threshold, otherwise null.
+const SIMILARITY_THRESHOLD = 0.5;
+async function findSimilarQuestion(topic, text) {
+  if (!text) return null;
+  try {
+    const result = await pool.query(
+      `SELECT q.text, similarity(q.text, $2) AS sim
+       FROM questions q
+       JOIN discussions d ON q.discussion_id = d.id
+       WHERE d.topic = $1 AND similarity(q.text, $2) > $3
+       ORDER BY sim DESC
+       LIMIT 1`,
+      [topic, text, SIMILARITY_THRESHOLD]
+    );
+    return result.rows.length > 0 ? result.rows[0].text : null;
+  } catch (e) {
+    // If pg_trgm isn't available, skip dedup rather than blocking submission.
+    console.error('Similarity check failed (skipping dedup):', e.message);
+    return null;
+  }
+}
 
 async function addVote(questionId, vote, userId, pseudonym) {
   console.log('Adding vote:', questionId, vote, userId, pseudonym);


### PR DESCRIPTION
## ⚠️ Re-targeted to `main` to fix a tangled merge

The original stack merged into the wrong branches:
- **#23** (foundation: identity/pseudonyms, results viz) → merged into `main` ✅
- **#24** (live & social: presence, upvoting, share/QR) → was merged into the `adj-animal-pseudonyms` branch, **not `main`**, so its changes never landed.
- **#26** (this PR) → was targeting `pr2-live-social`.

This branch (`pr3-moderation-dedup`) contains the **full stack: PR1 + PR2 + PR3**. PR1 is already in `main`, so the diff here is exactly **PR2 + PR3**. Merging this brings both missing feature sets into `main` in one clean merge (verified: no conflicts). **#24 is now redundant** and can be closed.

## What this delivers

### Live & social (was #24)
- **Live presence** — server tracks room membership; header shows "N people here now".
- **Open-ended upvoting** — `response_votes` table; upvote button per response (not your own); responses sort by upvotes.
- **Share + QR** — Share modal with copy-link + a client-side QR code (`qrcode.react`).

### Moderation & dedup (#26)
- **Moderation** — `admin_token` / `locked` / `pinned` columns; first-come moderator claim; `?admin=` moderator link; token-guarded delete/lock/pin; locking closes voting + new statements server-side; pinned statements float to top.
- **Dedup** — `pg_trgm` trigram similarity on submit; near-duplicates prompt "vote on existing vs post anyway"; degrades gracefully if `pg_trgm` is unavailable.

## Test results
- ✅ Runtime-verified against a real Postgres (Docker): **23/23 socket-level checks** (dedup, moderation auth, lock enforcement, pin, upvote toggle, presence inc/dec).
- ✅ Client `npm run build`, ✅ ESLint clean, ✅ `node --check server.js`.
- ✅ Trial-merged into `main` locally: no conflicts.

## Dependency note
`qrcode.react@3.1.0` was added past the workspace's install-time minimum-package-age guard (a years-old, pinned, widely-used version; QR renders client-side with no external calls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)