### PR TITLE
Add Postgres test harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,27 @@ From there, users can submit questions and people can vote on how much they agre
 
 This is a React app with a Node.js backend. It uses WebSockets for real-time communication.
 
+## Local development
+
+Start Postgres with Docker Compose:
+
+```
+npm run dev:db
+```
+
+Run the backend against that database:
+
+```
+npm run dev:server:docker
+```
+
+Run the integration harness, which starts an isolated Docker Postgres and tests
+the real HTTP and Socket.IO paths:
+
+```
+npm test
+```
+
 ## Website
 
 [https://convora-e40a9ae358dc.herokuapp.com/](https://convora-e40a9ae358dc.herokuapp.com/)

--- a/README.md
+++ b/README.md
@@ -16,20 +16,20 @@ This is a React app with a Node.js backend. It uses WebSockets for real-time com
 
 Start Postgres with Docker Compose:
 
-```
+```bash
 npm run dev:db
 ```
 
 Run the backend against that database:
 
-```
+```bash
 npm run dev:server:docker
 ```
 
 Run the integration harness, which starts an isolated Docker Postgres and tests
 the real HTTP and Socket.IO paths:
 
-```
+```bash
 npm test
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-convora}
+      POSTGRES_USER: ${POSTGRES_USER:-convora}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-convora}
+    ports:
+      - "${POSTGRES_PORT:-54329}:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 2s
+      timeout: 5s
+      retries: 20
+
+volumes:
+  postgres-data:

--- a/docs/DEV_NOTES.md
+++ b/docs/DEV_NOTES.md
@@ -8,6 +8,32 @@ The frontend is React and the backend is Node.js.
 
 ## Running the Application Locally
 
+### Option A: Docker Postgres
+
+1. Start the local PostgreSQL container:
+   ```
+   npm run dev:db
+   ```
+
+2. Build the React app (if changes were made to the frontend):
+   ```
+   npm run build
+   ```
+
+3. Start the server against Docker Postgres:
+   ```
+   npm run dev:server:docker
+   ```
+
+4. Access the application at `http://localhost:3001`
+
+5. Stop Docker Postgres when you are done:
+   ```
+   npm run dev:db:down
+   ```
+
+### Option B: Local Postgres
+
 1. Start the PostgreSQL database server:
    ```
    brew services start postgresql@14
@@ -47,8 +73,10 @@ The frontend is React and the backend is Node.js.
 
 ## Databases
 
-- Name: `convora`
-- Connect: `psql -U julius -d convora`
+- Docker name: `convora`
+- Docker connect: `psql "postgresql://convora:convora@127.0.0.1:54329/convora"`
+- Local name: `convora`
+- Local connect: `psql -U julius -d convora`
 
 ### See tables
 
@@ -60,6 +88,26 @@ The frontend is React and the backend is Node.js.
 ### Connect to remote database
 
 `heroku pg:psql`
+
+## Tests
+
+This repo has a Postgres-backed integration harness that starts Docker Compose,
+boots the real server on an ephemeral port, and verifies both HTTP and Socket.IO
+flows.
+
+Run the full harness:
+```
+npm test
+```
+
+Run against an already-running database:
+```
+DATABASE_URL=postgresql://convora:convora@127.0.0.1:54330/convora_test npm run test:node
+```
+
+The default test harness uses a separate Docker Compose project and port
+(`convora-test`, `54330`) from the dev database (`54329`). Set `KEEP_TEST_DB=1`
+to leave the test database running after a failed run.
 
 ## Production Deployment on Heroku
 

--- a/docs/DEV_NOTES.md
+++ b/docs/DEV_NOTES.md
@@ -107,7 +107,10 @@ DATABASE_URL=postgresql://convora:convora@127.0.0.1:54330/convora_test npm run t
 
 The default test harness uses a separate Docker Compose project and port
 (`convora-test`, `54330`) from the dev database (`54329`). Set `KEEP_TEST_DB=1`
-to leave the test database running after a failed run.
+to leave the test database running after a failed run. Because the tests truncate
+tables between cases, they refuse to run unless `DATABASE_URL` points at a
+localhost database whose name ends with `_test`; set `ALLOW_NON_TEST_DATABASE=1`
+only for a disposable nonstandard test database.
 
 ## Production Deployment on Heroku
 

--- a/docs/DEV_NOTES.md
+++ b/docs/DEV_NOTES.md
@@ -11,24 +11,24 @@ The frontend is React and the backend is Node.js.
 ### Option A: Docker Postgres
 
 1. Start the local PostgreSQL container:
-   ```
+   ```bash
    npm run dev:db
    ```
 
 2. Build the React app (if changes were made to the frontend):
-   ```
+   ```bash
    npm run build
    ```
 
 3. Start the server against Docker Postgres:
-   ```
+   ```bash
    npm run dev:server:docker
    ```
 
 4. Access the application at `http://localhost:3001`
 
 5. Stop Docker Postgres when you are done:
-   ```
+   ```bash
    npm run dev:db:down
    ```
 
@@ -96,12 +96,12 @@ boots the real server on an ephemeral port, and verifies both HTTP and Socket.IO
 flows.
 
 Run the full harness:
-```
+```bash
 npm test
 ```
 
 Run against an already-running database:
-```
+```bash
 DATABASE_URL=postgresql://convora:convora@127.0.0.1:54330/convora_test npm run test:node
 ```
 
@@ -134,7 +134,7 @@ Push from a branch might make it a little easier to revert if it doesn't go well
 ## Other Notes
 
 The client and server are on the same domain, so I don't need to do things like this:
-```
+```javascript
 const socket = io(SOCKET_URL, {
     withCredentials: true,
 });

--- a/package.json
+++ b/package.json
@@ -9,8 +9,14 @@
     "scripts": {
         "start": "node server.js",
         "dev:server": "nodemon server.js",
+        "dev:server:docker": "DATABASE_URL=postgresql://convora:convora@127.0.0.1:54329/convora nodemon server.js",
         "dev:client": "cd client && vite",
+        "dev:db": "docker compose up -d postgres",
+        "dev:db:down": "docker compose down",
         "build": "cd client && vite build",
+        "test": "npm run test:integration",
+        "test:node": "node --test tests/integration.test.js",
+        "test:integration": "scripts/test-integration.sh",
         "heroku-postbuild": "npm install && cd client && npm install && npx vite build"
     },
     "keywords": [

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-convora-test}"
+export POSTGRES_DB="${POSTGRES_DB:-convora_test}"
+export POSTGRES_USER="${POSTGRES_USER:-convora}"
+export POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-convora}"
+export POSTGRES_PORT="${POSTGRES_PORT:-54330}"
+export DATABASE_URL="${DATABASE_URL:-postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:${POSTGRES_PORT}/${POSTGRES_DB}}"
+
+cleanup() {
+  if [ "${KEEP_TEST_DB:-0}" != "1" ]; then
+    docker compose down -v --remove-orphans >/dev/null
+  fi
+}
+trap cleanup EXIT
+
+docker compose up -d postgres
+
+for attempt in $(seq 1 30); do
+  if docker compose exec -T postgres pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" >/dev/null; then
+    npm run test:node
+    exit 0
+  fi
+
+  sleep 1
+done
+
+echo "Postgres did not become ready in time" >&2
+docker compose logs postgres >&2
+exit 1

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -16,6 +16,8 @@ let baseUrl;
 let pool;
 
 test.before(async () => {
+  assertSafeTestDatabase(databaseUrl);
+
   const port = await getAvailablePort();
   baseUrl = `http://127.0.0.1:${port}`;
   pool = new Pool({ connectionString: databaseUrl });
@@ -249,4 +251,21 @@ function collectServerOutput(chunk) {
 
 function uniqueTopic(prefix) {
   return `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function assertSafeTestDatabase(connectionString) {
+  if (process.env.ALLOW_NON_TEST_DATABASE === '1') {
+    return;
+  }
+
+  const url = new URL(connectionString);
+  const databaseName = url.pathname.replace(/^\//, '');
+  const localHosts = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+  if (!localHosts.has(url.hostname) || !databaseName.endsWith('_test')) {
+    throw new Error(
+      `Refusing to run destructive integration tests against ${url.hostname}/${databaseName}. ` +
+      'Use a localhost database whose name ends with "_test", or set ALLOW_NON_TEST_DATABASE=1 for a disposable database.'
+    );
+  }
 }

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -1,0 +1,252 @@
+const assert = require('node:assert/strict');
+const { spawn } = require('node:child_process');
+const net = require('node:net');
+const path = require('node:path');
+const { test } = require('node:test');
+const { once } = require('node:events');
+const { Pool } = require('pg');
+const { io } = require('socket.io-client');
+
+const rootDir = path.resolve(__dirname, '..');
+const databaseUrl = process.env.DATABASE_URL || 'postgresql://convora:convora@127.0.0.1:54330/convora_test';
+
+let serverProcess;
+let serverOutput = '';
+let baseUrl;
+let pool;
+
+test.before(async () => {
+  const port = await getAvailablePort();
+  baseUrl = `http://127.0.0.1:${port}`;
+  pool = new Pool({ connectionString: databaseUrl });
+
+  serverProcess = spawn(process.execPath, ['server.js'], {
+    cwd: rootDir,
+    env: {
+      ...process.env,
+      NODE_ENV: 'test',
+      PORT: String(port),
+      DATABASE_URL: databaseUrl,
+      CLIENT_URL: baseUrl,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  serverProcess.stdout.on('data', collectServerOutput);
+  serverProcess.stderr.on('data', collectServerOutput);
+
+  await waitForServer(baseUrl, serverProcess);
+});
+
+test.beforeEach(async () => {
+  await pool.query('TRUNCATE TABLE votes, questions, discussions RESTART IDENTITY CASCADE');
+});
+
+test.after(async () => {
+  if (pool) {
+    await pool.end();
+  }
+
+  if (serverProcess && serverProcess.exitCode === null) {
+    serverProcess.kill('SIGTERM');
+    await waitForExit(serverProcess);
+  }
+});
+
+test('server startup creates schema and applies the pseudonym migration', async () => {
+  const tables = await pool.query(`
+    SELECT table_name
+    FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name IN ('discussions', 'questions', 'votes')
+    ORDER BY table_name
+  `);
+  assert.deepEqual(tables.rows.map((row) => row.table_name), ['discussions', 'questions', 'votes']);
+
+  const columns = await pool.query(`
+    SELECT column_name
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'votes'
+      AND column_name = 'pseudonym'
+  `);
+  assert.equal(columns.rowCount, 1);
+});
+
+test('HTTP API creates and fetches discussions', async () => {
+  const topic = uniqueTopic('http');
+  const createResponse = await jsonRequest('POST', '/api/discussions', { topic });
+
+  assert.equal(createResponse.status, 200);
+  assert.equal(createResponse.body.success, true);
+  assert.equal(createResponse.body.id, 1);
+
+  const fetchResponse = await jsonRequest('GET', `/api/discussions/${createResponse.body.id}`);
+  assert.equal(fetchResponse.status, 200);
+  assert.equal(fetchResponse.body.topic, topic);
+});
+
+test('Socket.IO adds questions and broadcasts votes with pseudonyms', async () => {
+  const topic = uniqueTopic('socket');
+  const author = await connectSocket();
+  const voter = await connectSocket();
+
+  try {
+    const authorInitialQuestions = waitForQuestions(author, (questions) => Array.isArray(questions), 'author join');
+    author.emit('joinDiscussion', topic);
+    assert.deepEqual(await authorInitialQuestions, []);
+
+    const voterInitialQuestions = waitForQuestions(voter, (questions) => Array.isArray(questions), 'voter join');
+    voter.emit('joinDiscussion', topic);
+    assert.deepEqual(await voterInitialQuestions, []);
+
+    const questionUpdate = waitForQuestions(
+      author,
+      (questions) => questions.length === 1 && questions[0].text === 'Should this harness exist?',
+      'question broadcast'
+    );
+
+    author.emit('addQuestion', topic, {
+      text: 'Should this harness exist?',
+      type: 'Agreement',
+      minValue: null,
+      maxValue: null,
+      options: [],
+    });
+
+    const questions = await questionUpdate;
+    const question = questions[0];
+    assert.equal(question.type, 'Agreement');
+    assert.deepEqual(question.options, []);
+
+    const voteUpdate = waitForQuestions(
+      author,
+      (updatedQuestions) => updatedQuestions[0] && updatedQuestions[0].votes.length === 1,
+      'vote broadcast'
+    );
+
+    voter.emit('vote', topic, question.id, 'Agree', 'user-1', 'Careful Tester');
+
+    const updatedQuestions = await voteUpdate;
+    assert.equal(updatedQuestions[0].votes[0].value, 'Agree');
+    assert.equal(updatedQuestions[0].votes[0].userId, 'user-1');
+    assert.equal(updatedQuestions[0].votes[0].pseudonym, 'Careful Tester');
+  } finally {
+    author.disconnect();
+    voter.disconnect();
+  }
+});
+
+async function jsonRequest(method, urlPath, body) {
+  const response = await fetch(`${baseUrl}${urlPath}`, {
+    method,
+    headers: body === undefined ? undefined : { 'Content-Type': 'application/json' },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+  return {
+    status: response.status,
+    body: await response.json(),
+  };
+}
+
+function connectSocket() {
+  const socket = io(baseUrl, {
+    forceNew: true,
+    reconnection: false,
+    transports: ['websocket'],
+  });
+
+  return withTimeout(
+    new Promise((resolve, reject) => {
+      socket.once('connect', () => resolve(socket));
+      socket.once('connect_error', reject);
+    }),
+    5000,
+    'Timed out connecting Socket.IO client'
+  );
+}
+
+function waitForQuestions(socket, predicate, description) {
+  return withTimeout(
+    new Promise((resolve) => {
+      const handler = (questions) => {
+        if (predicate(questions)) {
+          socket.off('questions', handler);
+          resolve(questions);
+        }
+      };
+
+      socket.on('questions', handler);
+    }),
+    5000,
+    `Timed out waiting for ${description}`
+  );
+}
+
+function waitForServer(url, childProcess) {
+  return withTimeout(
+    new Promise((resolve, reject) => {
+      const interval = setInterval(async () => {
+        if (childProcess.exitCode !== null) {
+          clearInterval(interval);
+          reject(new Error(`Server exited early with code ${childProcess.exitCode}\n${serverOutput}`));
+          return;
+        }
+
+        try {
+          const response = await fetch(`${url}/api/discussions`);
+          if (response.ok) {
+            clearInterval(interval);
+            resolve();
+          }
+        } catch {
+          // Keep polling until the server accepts connections or the timeout wins.
+        }
+      }, 100);
+    }),
+    10000,
+    `Timed out waiting for server to start\n${serverOutput}`
+  );
+}
+
+function getAvailablePort() {
+  return new Promise((resolve, reject) => {
+    const probe = net.createServer();
+
+    probe.once('error', reject);
+    probe.listen(0, '127.0.0.1', () => {
+      const { port } = probe.address();
+      probe.close(() => resolve(port));
+    });
+  });
+}
+
+async function waitForExit(childProcess) {
+  try {
+    await withTimeout(once(childProcess, 'exit'), 5000, 'Timed out waiting for server process to exit');
+  } catch {
+    childProcess.kill('SIGKILL');
+    await once(childProcess, 'exit');
+  }
+}
+
+function withTimeout(promise, milliseconds, message) {
+  let timeout;
+  const timeoutPromise = new Promise((_, reject) => {
+    timeout = setTimeout(() => reject(new Error(message)), milliseconds);
+  });
+
+  return Promise.race([promise, timeoutPromise]).finally(() => clearTimeout(timeout));
+}
+
+function collectServerOutput(chunk) {
+  serverOutput += chunk.toString();
+  if (serverOutput.length > 8000) {
+    serverOutput = serverOutput.slice(-8000);
+  }
+}
+
+function uniqueTopic(prefix) {
+  return `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -187,29 +187,30 @@ function waitForQuestions(socket, predicate, description) {
 }
 
 function waitForServer(url, childProcess) {
-  return withTimeout(
-    new Promise((resolve, reject) => {
-      const interval = setInterval(async () => {
-        if (childProcess.exitCode !== null) {
-          clearInterval(interval);
-          reject(new Error(`Server exited early with code ${childProcess.exitCode}\n${serverOutput}`));
-          return;
-        }
+  let interval;
+  const readiness = new Promise((resolve, reject) => {
+    interval = setInterval(async () => {
+      if (childProcess.exitCode !== null) {
+        reject(new Error(`Server exited early with code ${childProcess.exitCode}\n${serverOutput}`));
+        return;
+      }
 
-        try {
-          const response = await fetch(`${url}/api/discussions`);
-          if (response.ok) {
-            clearInterval(interval);
-            resolve();
-          }
-        } catch {
-          // Keep polling until the server accepts connections or the timeout wins.
+      try {
+        const response = await fetch(`${url}/api/discussions`);
+        if (response.ok) {
+          resolve();
         }
-      }, 100);
-    }),
+      } catch {
+        // Keep polling until the server accepts connections or the timeout wins.
+      }
+    }, 100);
+  });
+
+  return withTimeout(
+    readiness,
     10000,
     `Timed out waiting for server to start\n${serverOutput}`
-  );
+  ).finally(() => clearInterval(interval));
 }
 
 function getAvailablePort() {


### PR DESCRIPTION
Adds a Docker Compose Postgres service plus npm scripts for local database startup and integration testing.

The new harness starts an isolated test database, boots the real server on an ephemeral port, and verifies schema/migration startup, HTTP discussion creation/fetching, and Socket.IO question/vote broadcasts with pseudonyms.

Docs now cover the Docker-backed dev database and the test workflow.

Validated with `npm test`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added local development setup guide with Docker PostgreSQL configuration to README
  * Expanded developer documentation with setup workflows and testing instructions

* **Tests**
  * Added comprehensive integration test suite covering HTTP and real-time communication paths

* **Chores**
  * Added Docker Compose configuration for PostgreSQL
  * Introduced npm scripts for Docker-based development and testing workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->