### PR TITLE
[codex] Add discussion summary exports

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link, Route, BrowserRouter as Router, Routes } from 'react-router-dom';
 import DiscussionPage from './DiscussionPage';
 import HomePage from './HomePage';
+import SummaryPage from './SummaryPage';
 
 const App = () => {
     return (
@@ -16,6 +17,7 @@ const App = () => {
                     <Routes>
                         <Route path="/" element={<HomePage />} />
                         <Route path="/discussion/:topic" element={<DiscussionPage />} />
+                        <Route path="/discussion/:topic/summary" element={<SummaryPage />} />
                     </Routes>
                 </main>
             </div>

--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import io from 'socket.io-client';
 import { getIdentity, regeneratePseudonym } from './identity';
 
@@ -221,7 +221,7 @@ const DiscussionPage = () => {
     const sortQuestions = (questions) => {
         switch (sortOption) {
             case SortOptions.MOST_RECENT:
-                return [...questions].sort((a, b) => b.timestamp - a.timestamp);
+                return [...questions].sort((a, b) => getQuestionSortTime(b) - getQuestionSortTime(a));
             case SortOptions.MOST_AGREEMENT:
                 return [...questions].sort((a, b) => getAgreementCount(b) - getAgreementCount(a));
             case SortOptions.MOST_DISAGREEMENT:
@@ -245,6 +245,14 @@ const DiscussionPage = () => {
         const agreementCount = getAgreementCount(question);
         const disagreementCount = getDisagreementCount(question);
         return Math.min(agreementCount, disagreementCount);
+    };
+
+    const getQuestionSortTime = (question) => {
+        if (question.timestamp) {
+            return question.timestamp;
+        }
+        const createdAt = Date.parse(question.created_at);
+        return Number.isNaN(createdAt) ? 0 : createdAt;
     };
 
     const filterQuestions = (questions) => {
@@ -358,13 +366,32 @@ const DiscussionPage = () => {
                 </button>
             </div>
 
-            {/* Duplicate Discussion Button */}
-            <button
-                onClick={() => setShowDuplicateModal(true)}
-                className="mb-4 bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 transition duration-300"
-            >
-                Duplicate Discussion
-            </button>
+            <div className="mb-4 flex flex-wrap gap-3">
+                <button
+                    onClick={() => setShowDuplicateModal(true)}
+                    className="bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 transition duration-300"
+                >
+                    Duplicate Discussion
+                </button>
+                <Link
+                    to={`/discussion/${topic}/summary`}
+                    className="bg-gray-800 text-white py-2 px-4 rounded hover:bg-gray-700 transition duration-300"
+                >
+                    View Summary
+                </Link>
+                <a
+                    href={`/api/discussions/${encodeURIComponent(topic)}/export.csv`}
+                    className="bg-primary text-white py-2 px-4 rounded hover:bg-opacity-90 transition duration-300"
+                >
+                    Export CSV
+                </a>
+                <a
+                    href={`/api/discussions/${encodeURIComponent(topic)}/export.json`}
+                    className="bg-secondary text-white py-2 px-4 rounded hover:bg-opacity-90 transition duration-300"
+                >
+                    Export JSON
+                </a>
+            </div>
 
             {/* Duplicate Modal */}
             {showDuplicateModal && (

--- a/client/src/SummaryPage.jsx
+++ b/client/src/SummaryPage.jsx
@@ -1,0 +1,411 @@
+import PropTypes from 'prop-types';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+
+const AGREEMENT_OPTIONS = [
+    'Strongly Disagree',
+    'Disagree',
+    'Unsure',
+    'Agree',
+    'Strongly Agree',
+];
+
+function formatPercent(value) {
+    if (!Number.isFinite(value)) {
+        return '0%';
+    }
+    return `${Math.round(value * 100)}%`;
+}
+
+function formatNumber(value, digits = 1) {
+    if (value === null || value === undefined || Number.isNaN(Number(value))) {
+        return '-';
+    }
+    return Number(value).toFixed(digits);
+}
+
+function formatDate(value) {
+    if (!value) {
+        return '';
+    }
+    return new Date(value).toLocaleString();
+}
+
+const SummaryPage = () => {
+    const { topic } = useParams();
+    const [summary, setSummary] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [synthesisLoading, setSynthesisLoading] = useState(false);
+    const [error, setError] = useState(null);
+
+    const encodedTopic = encodeURIComponent(topic);
+
+    const loadSummary = useCallback(async ({ llm = false } = {}) => {
+        if (llm) {
+            setSynthesisLoading(true);
+        } else {
+            setLoading(true);
+        }
+        setError(null);
+
+        try {
+            const suffix = llm ? '?synthesis=llm' : '';
+            const response = await fetch(`/api/discussions/${encodedTopic}/summary${suffix}`);
+            if (!response.ok) {
+                throw new Error('Failed to load summary');
+            }
+            const data = await response.json();
+            setSummary(data);
+        } catch (err) {
+            console.error('Error loading summary:', err);
+            setError('Could not load the discussion summary.');
+        } finally {
+            setLoading(false);
+            setSynthesisLoading(false);
+        }
+    }, [encodedTopic]);
+
+    useEffect(() => {
+        loadSummary();
+    }, [loadSummary]);
+
+    if (loading) {
+        return <div className="max-w-5xl mx-auto mt-10 px-4 text-gray-600">Loading summary...</div>;
+    }
+
+    if (error) {
+        return (
+            <div className="max-w-5xl mx-auto mt-10 px-4">
+                <p className="text-red-600 mb-4">{error}</p>
+                <Link to={`/discussion/${topic}`} className="text-primary hover:underline">Back to discussion</Link>
+            </div>
+        );
+    }
+
+    if (!summary) {
+        return null;
+    }
+
+    return (
+        <div className="max-w-5xl mx-auto mt-10 px-4">
+            <div className="mb-6">
+                <Link to={`/discussion/${topic}`} className="text-primary hover:underline">
+                    Back to discussion
+                </Link>
+                <h1 className="text-4xl font-bold mt-3 mb-2 text-gray-800">Summary: {summary.discussion.topic}</h1>
+                <p className="text-sm text-gray-500">Created {formatDate(summary.discussion.createdAt)}</p>
+            </div>
+
+            <div className="flex flex-wrap gap-3 mb-8">
+                <a
+                    href={`/api/discussions/${encodedTopic}/export.csv`}
+                    className="bg-primary text-white px-4 py-2 rounded-md hover:bg-opacity-90 transition duration-300"
+                >
+                    Export CSV
+                </a>
+                <a
+                    href={`/api/discussions/${encodedTopic}/export.json`}
+                    className="bg-secondary text-white px-4 py-2 rounded-md hover:bg-opacity-90 transition duration-300"
+                >
+                    Export JSON
+                </a>
+                <button
+                    onClick={() => loadSummary({ llm: true })}
+                    disabled={synthesisLoading}
+                    className="bg-gray-800 text-white px-4 py-2 rounded-md hover:bg-gray-700 transition duration-300 disabled:opacity-50"
+                >
+                    {synthesisLoading ? 'Generating...' : 'Generate Synthesis'}
+                </button>
+            </div>
+
+            <section className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
+                <CountCard label="Questions" value={summary.counts.questions} />
+                <CountCard label="Responses" value={summary.counts.responses} />
+                <CountCard label="Participants" value={summary.counts.participants} />
+                <CountCard label="Agreement Items" value={summary.counts.byType?.Agreement || 0} />
+            </section>
+
+            <section className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+                <RankedAgreementList
+                    title="Top Consensus"
+                    items={summary.topConsensus}
+                    metricLabel="Consensus"
+                    metricKey="consensusScore"
+                />
+                <RankedAgreementList
+                    title="Top Divisive"
+                    items={summary.topDivisive}
+                    metricLabel="Split"
+                    metricKey="divisiveScore"
+                />
+            </section>
+
+            <SynthesisPanel synthesis={summary.synthesis} />
+
+            <section className="mt-8">
+                <h2 className="text-2xl font-bold mb-4 text-gray-800">Question Counts</h2>
+                <div className="space-y-4">
+                    {summary.questions.map(question => (
+                        <QuestionSummary key={question.id} question={question} />
+                    ))}
+                </div>
+            </section>
+        </div>
+    );
+};
+
+const CountCard = ({ label, value }) => (
+    <div className="bg-white shadow rounded-lg p-5">
+        <div className="text-sm font-semibold text-gray-500 uppercase tracking-wide">{label}</div>
+        <div className="text-3xl font-bold text-gray-900 mt-2">{value}</div>
+    </div>
+);
+
+CountCard.propTypes = {
+    label: PropTypes.string.isRequired,
+    value: PropTypes.number.isRequired,
+};
+
+const RankedAgreementList = ({ title, items, metricLabel, metricKey }) => (
+    <section className="bg-white shadow rounded-lg p-6">
+        <h2 className="text-2xl font-bold mb-4 text-gray-800">{title}</h2>
+        {items.length === 0 ? (
+            <p className="text-sm text-gray-500">No agreement responses yet.</p>
+        ) : (
+            <ol className="space-y-4">
+                {items.map(item => (
+                    <li key={item.id} className="border-b border-gray-100 last:border-0 pb-4 last:pb-0">
+                        <div className="flex items-start justify-between gap-4">
+                            <div>
+                                <h3 className="font-semibold text-gray-900">{item.text}</h3>
+                                <p className="text-sm text-gray-500 mt-1">
+                                    {item.responseCount} {item.responseCount === 1 ? 'response' : 'responses'} - {item.leadingPosition}
+                                </p>
+                            </div>
+                            <span className="text-sm font-semibold text-gray-800 whitespace-nowrap">
+                                {metricLabel}: {formatPercent(item[metricKey])}
+                            </span>
+                        </div>
+                        <AgreementBar optionCounts={item.optionCounts} total={item.responseCount} />
+                    </li>
+                ))}
+            </ol>
+        )}
+    </section>
+);
+
+const AgreementItemShape = PropTypes.shape({
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    text: PropTypes.string.isRequired,
+    responseCount: PropTypes.number.isRequired,
+    leadingPosition: PropTypes.string,
+    consensusScore: PropTypes.number,
+    divisiveScore: PropTypes.number,
+    optionCounts: PropTypes.objectOf(PropTypes.number).isRequired,
+});
+
+RankedAgreementList.propTypes = {
+    title: PropTypes.string.isRequired,
+    items: PropTypes.arrayOf(AgreementItemShape).isRequired,
+    metricLabel: PropTypes.string.isRequired,
+    metricKey: PropTypes.string.isRequired,
+};
+
+const AgreementBar = ({ optionCounts, total }) => {
+    if (!total) {
+        return null;
+    }
+
+    const colors = {
+        'Strongly Disagree': 'bg-red-600',
+        Disagree: 'bg-red-400',
+        Unsure: 'bg-gray-400',
+        Agree: 'bg-green-400',
+        'Strongly Agree': 'bg-green-600',
+    };
+
+    return (
+        <div className="mt-3">
+            <div className="flex w-full h-3 rounded-full overflow-hidden bg-gray-200">
+                {AGREEMENT_OPTIONS.map(option => {
+                    const count = optionCounts[option] || 0;
+                    if (count === 0) {
+                        return null;
+                    }
+                    return (
+                        <div
+                            key={option}
+                            className={colors[option]}
+                            style={{ width: `${(count / total) * 100}%` }}
+                            title={`${option}: ${count}`}
+                        />
+                    );
+                })}
+            </div>
+            <div className="flex flex-wrap gap-x-3 gap-y-1 mt-2 text-xs text-gray-500">
+                {AGREEMENT_OPTIONS.map(option => (
+                    <span key={option}>{option}: {optionCounts[option] || 0}</span>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+AgreementBar.propTypes = {
+    optionCounts: PropTypes.objectOf(PropTypes.number).isRequired,
+    total: PropTypes.number.isRequired,
+};
+
+const SynthesisPanel = ({ synthesis }) => (
+    <section className="bg-white shadow rounded-lg p-6">
+        <div className="flex items-center justify-between gap-4 mb-4">
+            <h2 className="text-2xl font-bold text-gray-800">Written Response Synthesis</h2>
+            {synthesis?.mode && (
+                <span className="px-2 py-1 text-xs font-semibold rounded-full bg-gray-100 text-gray-700">
+                    {synthesis.mode === 'llm' ? 'LLM' : 'Auto'}
+                </span>
+            )}
+        </div>
+
+        {!synthesis ? (
+            <p className="text-sm text-gray-500">No open-ended responses yet.</p>
+        ) : synthesis.mode === 'llm' ? (
+            <div className="space-y-4">
+                {synthesis.synthesis && <p className="text-gray-800">{synthesis.synthesis}</p>}
+                <SynthesisList title="Common Themes" items={synthesis.commonThemes} />
+                <SynthesisList title="Unresolved Questions" items={synthesis.unresolvedQuestions} />
+                <SynthesisList title="Notable Divergences" items={synthesis.notableDivergences} />
+            </div>
+        ) : (
+            <div className="space-y-4">
+                <p className="text-gray-800">{synthesis.text}</p>
+                {synthesis.llmError && <p className="text-sm text-amber-700">{synthesis.llmError}</p>}
+                {synthesis.highlights?.length > 0 && (
+                    <div>
+                        <h3 className="font-semibold mb-2 text-gray-800">Prompts</h3>
+                        <ul className="list-disc pl-5 text-gray-700 space-y-1">
+                            {synthesis.highlights.map(item => (
+                                <li key={item.question}>{item.question}: {item.responseCount}</li>
+                            ))}
+                        </ul>
+                    </div>
+                )}
+                {synthesis.excerpts?.length > 0 && (
+                    <div>
+                        <h3 className="font-semibold mb-2 text-gray-800">Representative Excerpts</h3>
+                        <ul className="space-y-2">
+                            {synthesis.excerpts.map((item, index) => (
+                                <li key={`${item.question}-${index}`} className="bg-gray-50 rounded-md p-3">
+                                    <div className="text-xs font-semibold text-gray-500 mb-1">{item.question}</div>
+                                    <div className="text-gray-800">{item.excerpt}</div>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                )}
+            </div>
+        )}
+    </section>
+);
+
+SynthesisPanel.propTypes = {
+    synthesis: PropTypes.shape({
+        mode: PropTypes.string,
+        text: PropTypes.string,
+        llmError: PropTypes.string,
+        synthesis: PropTypes.string,
+        commonThemes: PropTypes.array,
+        unresolvedQuestions: PropTypes.array,
+        notableDivergences: PropTypes.array,
+        highlights: PropTypes.arrayOf(PropTypes.shape({
+            question: PropTypes.string.isRequired,
+            responseCount: PropTypes.number.isRequired,
+        })),
+        excerpts: PropTypes.arrayOf(PropTypes.shape({
+            question: PropTypes.string.isRequired,
+            excerpt: PropTypes.string.isRequired,
+        })),
+    }),
+};
+
+const SynthesisList = ({ title, items }) => {
+    if (!Array.isArray(items) || items.length === 0) {
+        return null;
+    }
+
+    return (
+        <div>
+            <h3 className="font-semibold mb-2 text-gray-800">{title}</h3>
+            <ul className="list-disc pl-5 text-gray-700 space-y-1">
+                {items.map((item, index) => (
+                    <li key={`${title}-${index}`}>{typeof item === 'string' ? item : JSON.stringify(item)}</li>
+                ))}
+            </ul>
+        </div>
+    );
+};
+
+SynthesisList.propTypes = {
+    title: PropTypes.string.isRequired,
+    items: PropTypes.array,
+};
+
+const QuestionSummary = ({ question }) => (
+    <article className="bg-white shadow rounded-lg p-5">
+        <div className="flex flex-wrap items-start justify-between gap-3 mb-3">
+            <div>
+                <h3 className="text-lg font-semibold text-gray-900">{question.text}</h3>
+                <p className="text-sm text-gray-500">{question.type} - {question.responseCount} {question.responseCount === 1 ? 'response' : 'responses'}</p>
+            </div>
+            {question.label && (
+                <span className="px-2 py-1 text-xs font-semibold rounded-full bg-gray-100 text-gray-700">{question.label}</span>
+            )}
+        </div>
+
+        {question.type === 'Agreement' && (
+            <AgreementBar optionCounts={question.optionCounts} total={question.responseCount} />
+        )}
+
+        {question.type === 'Numerical' && (
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm text-gray-700">
+                <span>Average: <strong>{formatNumber(question.average)}</strong></span>
+                <span>Low: <strong>{formatNumber(question.minResponse, 0)}</strong></span>
+                <span>High: <strong>{formatNumber(question.maxResponse, 0)}</strong></span>
+                <span>Std dev: <strong>{formatNumber(question.standardDeviation)}</strong></span>
+            </div>
+        )}
+
+        {(question.type === 'Open Ended' || question.type === 'Brainstorm') && question.responses?.length > 0 && (
+            <ul className="space-y-2 mt-3">
+                {question.responses.slice(0, 5).map(response => (
+                    <li key={response.id} className="bg-gray-50 rounded-md p-3">
+                        <div className="text-xs font-semibold text-gray-500 mb-1">{response.pseudonym}</div>
+                        <div className="text-gray-800 whitespace-pre-wrap">{String(response.value)}</div>
+                    </li>
+                ))}
+            </ul>
+        )}
+    </article>
+);
+
+QuestionSummary.propTypes = {
+    question: PropTypes.shape({
+        id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+        text: PropTypes.string.isRequired,
+        type: PropTypes.string.isRequired,
+        responseCount: PropTypes.number.isRequired,
+        label: PropTypes.string,
+        optionCounts: PropTypes.objectOf(PropTypes.number),
+        average: PropTypes.number,
+        minResponse: PropTypes.number,
+        maxResponse: PropTypes.number,
+        standardDeviation: PropTypes.number,
+        responses: PropTypes.arrayOf(PropTypes.shape({
+            id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+            pseudonym: PropTypes.string.isRequired,
+            value: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+        })),
+    }).isRequired,
+};
+
+export default SummaryPage;

--- a/server.js
+++ b/server.js
@@ -58,6 +58,253 @@ function parseOptions(options) {
   return [String(options)];
 }
 
+const AGREEMENT_OPTIONS = [
+  'Strongly Disagree',
+  'Disagree',
+  'Unsure',
+  'Agree',
+  'Strongly Agree',
+];
+
+function sanitizeFilename(value) {
+  return String(value || 'discussion')
+    .replace(/[^a-z0-9-_]+/gi, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80) || 'discussion';
+}
+
+function escapeCsv(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  const stringValue = Array.isArray(value) ? JSON.stringify(value) : String(value);
+  return `"${stringValue.replace(/"/g, '""')}"`;
+}
+
+function parseStoredVoteValue(value) {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  try {
+    return JSON.parse(value);
+  } catch (e) {
+    return value;
+  }
+}
+
+function getQuestionRange(question) {
+  const min = Number.parseInt(question.min_value, 10);
+  const max = Number.parseInt(question.max_value, 10);
+  return {
+    minValue: Number.isNaN(min) ? 0 : min,
+    maxValue: Number.isNaN(max) ? 100 : max,
+  };
+}
+
+function buildDeterministicSynthesis(writtenResponses) {
+  if (writtenResponses.length === 0) {
+    return null;
+  }
+
+  const byQuestion = writtenResponses.reduce((acc, response) => {
+    if (!acc.has(response.questionText)) {
+      acc.set(response.questionText, []);
+    }
+    acc.get(response.questionText).push(response.value);
+    return acc;
+  }, new Map());
+
+  const longestResponses = [...writtenResponses]
+    .sort((a, b) => b.value.length - a.value.length)
+    .slice(0, 3)
+    .map(response => ({
+      question: response.questionText,
+      excerpt: response.value.length > 180 ? `${response.value.slice(0, 177)}...` : response.value,
+    }));
+
+  return {
+    mode: 'deterministic',
+    text: `${writtenResponses.length} written ${writtenResponses.length === 1 ? 'response' : 'responses'} across ${byQuestion.size} ${byQuestion.size === 1 ? 'prompt' : 'prompts'}.`,
+    highlights: [...byQuestion.entries()].map(([question, responses]) => ({
+      question,
+      responseCount: responses.length,
+    })),
+    excerpts: longestResponses,
+  };
+}
+
+async function buildLlmSynthesis(writtenResponses) {
+  if (
+    writtenResponses.length === 0 ||
+    process.env.ENABLE_LLM_SYNTHESIS !== 'true' ||
+    !process.env.OPENAI_API_KEY
+  ) {
+    return null;
+  }
+
+  const payload = writtenResponses.slice(0, 80).map(response => ({
+    question: response.questionText,
+    response: response.value,
+  }));
+
+  const response = await fetch('https://api.openai.com/v1/responses', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+    },
+    body: JSON.stringify({
+      model: process.env.OPENAI_MODEL || 'gpt-4.1-mini',
+      input: [
+        {
+          role: 'system',
+          content: 'Summarize open-ended discussion responses for a read-only post-discussion report. Be concise, neutral, and preserve unresolved tensions.',
+        },
+        {
+          role: 'user',
+          content: `Return JSON with keys synthesis, commonThemes, unresolvedQuestions, and notableDivergences. Responses: ${JSON.stringify(payload)}`,
+        },
+      ],
+      text: {
+        format: {
+          type: 'json_object',
+        },
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`LLM synthesis failed: ${response.status} ${errorText}`);
+  }
+
+  const data = await response.json();
+  const outputText = data.output_text;
+  if (!outputText) {
+    return null;
+  }
+
+  return {
+    mode: 'llm',
+    ...JSON.parse(outputText),
+  };
+}
+
+function buildSummary(discussion, questions, synthesis) {
+  const participantIds = new Set();
+  const typeCounts = {};
+  let totalResponses = 0;
+
+  const questionSummaries = questions.map((question) => {
+    const votes = question.votes || [];
+    votes.forEach((vote) => {
+      if (vote.userId) {
+        participantIds.add(vote.userId);
+      }
+    });
+    totalResponses += votes.length;
+    typeCounts[question.type] = (typeCounts[question.type] || 0) + 1;
+
+    const base = {
+      id: question.id,
+      text: question.text,
+      type: question.type,
+      createdAt: question.created_at,
+      responseCount: votes.length,
+    };
+
+    if (question.type === 'Agreement') {
+      const optionCounts = AGREEMENT_OPTIONS.reduce((acc, option) => {
+        acc[option] = votes.filter(vote => vote.value === option).length;
+        return acc;
+      }, {});
+      const agreeCount = optionCounts.Agree + optionCounts['Strongly Agree'];
+      const disagreeCount = optionCounts.Disagree + optionCounts['Strongly Disagree'];
+      const decidedCount = agreeCount + disagreeCount;
+      const consensusScore = decidedCount > 0 ? Math.max(agreeCount, disagreeCount) / decidedCount : 0;
+      const divisiveScore = decidedCount > 0 ? Math.min(agreeCount, disagreeCount) / decidedCount : 0;
+
+      return {
+        ...base,
+        optionCounts,
+        agreeCount,
+        disagreeCount,
+        unsureCount: optionCounts.Unsure,
+        decidedCount,
+        consensusScore,
+        divisiveScore,
+        label: decidedCount < 2 ? 'Not enough votes' : divisiveScore >= 0.4 ? 'Divisive' : consensusScore >= 0.85 ? 'Consensus' : 'Mixed',
+        leadingPosition: agreeCount === disagreeCount ? 'Split' : agreeCount > disagreeCount ? 'Agree' : 'Disagree',
+      };
+    }
+
+    if (question.type === 'Numerical') {
+      const values = votes
+        .map(vote => Number.parseFloat(vote.value))
+        .filter(value => !Number.isNaN(value));
+      const average = values.length > 0 ? values.reduce((sum, value) => sum + value, 0) / values.length : null;
+      const variance = values.length > 0
+        ? values.reduce((sum, value) => sum + ((value - average) ** 2), 0) / values.length
+        : null;
+      const { minValue, maxValue } = getQuestionRange(question);
+
+      return {
+        ...base,
+        minValue,
+        maxValue,
+        average,
+        minResponse: values.length > 0 ? Math.min(...values) : null,
+        maxResponse: values.length > 0 ? Math.max(...values) : null,
+        standardDeviation: variance === null ? null : Math.sqrt(variance),
+      };
+    }
+
+    return {
+      ...base,
+      responses: votes.map(vote => ({
+        id: vote.id,
+        pseudonym: vote.pseudonym || 'Anonymous',
+        value: parseStoredVoteValue(vote.value),
+        createdAt: vote.created_at,
+      })),
+    };
+  });
+
+  const agreementSummaries = questionSummaries.filter(summary => summary.type === 'Agreement' && summary.decidedCount >= 2);
+  const topConsensus = [...agreementSummaries]
+    .sort((a, b) => b.consensusScore - a.consensusScore || b.responseCount - a.responseCount)
+    .slice(0, 5);
+  const topDivisive = [...agreementSummaries]
+    .sort((a, b) => b.divisiveScore - a.divisiveScore || b.responseCount - a.responseCount)
+    .slice(0, 5);
+
+  return {
+    discussion: {
+      id: discussion.id,
+      topic: discussion.topic,
+      createdAt: discussion.created_at,
+    },
+    counts: {
+      questions: questions.length,
+      responses: totalResponses,
+      participants: participantIds.size,
+      byType: typeCounts,
+    },
+    topConsensus,
+    topDivisive,
+    synthesis,
+    questions: questionSummaries,
+  };
+}
+
+async function getDiscussionByTopic(topic) {
+  const result = await pool.query(
+    'SELECT id, topic, created_at FROM discussions WHERE topic = $1 ORDER BY id DESC LIMIT 1',
+    [topic]
+  );
+  return result.rows[0] || null;
+}
+
 app.use(bodyParser.json());
 app.use(express.static(path.join(__dirname, 'dist')));
 
@@ -168,12 +415,14 @@ async function getQuestions(topic) {
       q.min_value, 
       q.max_value, 
       q.options,
+      q.created_at,
       COALESCE(json_agg(
         json_build_object(
           'id', v.id,
           'value', v.value,
           'userId', v.user_id,
-          'pseudonym', v.pseudonym
+          'pseudonym', v.pseudonym,
+          'created_at', v.created_at
         ) ORDER BY v.id
       ) FILTER (WHERE v.id IS NOT NULL), '[]'::json) as votes
     FROM questions q
@@ -187,6 +436,8 @@ async function getQuestions(topic) {
   const result = await pool.query(query, [topic]);
   return result.rows.map(row => ({
     ...row,
+    minValue: row.min_value,
+    maxValue: row.max_value,
     options: parseOptions(row.options)
   }));
 }
@@ -336,6 +587,150 @@ app.get('/api/discussions', async (req, res) => {
       'SELECT id, topic, created_at FROM discussions ORDER BY created_at DESC'
     );
     res.json(result.rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+async function getDiscussionSummary(topic, options = {}) {
+  const discussion = await getDiscussionByTopic(topic);
+  if (!discussion) {
+    return null;
+  }
+
+  const questions = await getQuestions(topic);
+  const writtenResponses = questions
+    .filter(question => question.type === 'Open Ended' || question.type === 'Brainstorm')
+    .flatMap(question => (question.votes || [])
+      .map(vote => ({
+        questionId: question.id,
+        questionText: question.text,
+        questionType: question.type,
+        pseudonym: vote.pseudonym || 'Anonymous',
+        value: String(parseStoredVoteValue(vote.value) || '').trim(),
+      }))
+      .filter(response => response.value !== ''));
+
+  let synthesis = buildDeterministicSynthesis(writtenResponses);
+  if (options.llm) {
+    if (
+      writtenResponses.length > 0 &&
+      (process.env.ENABLE_LLM_SYNTHESIS !== 'true' || !process.env.OPENAI_API_KEY)
+    ) {
+      synthesis = {
+        ...synthesis,
+        llmError: 'LLM synthesis is not configured, so the deterministic summary is shown.',
+      };
+    } else {
+      try {
+        const llmSynthesis = await buildLlmSynthesis(writtenResponses);
+        if (llmSynthesis) {
+          synthesis = llmSynthesis;
+        }
+      } catch (error) {
+        console.error('Error generating LLM synthesis:', error);
+        synthesis = {
+          ...synthesis,
+          llmError: 'LLM synthesis was unavailable, so the deterministic summary is shown.',
+        };
+      }
+    }
+  }
+
+  return buildSummary(discussion, questions, synthesis);
+}
+
+app.get('/api/discussions/:topic/summary', async (req, res) => {
+  try {
+    const summary = await getDiscussionSummary(req.params.topic, {
+      llm: req.query.synthesis === 'llm',
+    });
+
+    if (!summary) {
+      return res.status(404).json({ error: 'Discussion not found' });
+    }
+
+    res.json(summary);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+app.get('/api/discussions/:topic/export.json', async (req, res) => {
+  try {
+    const summary = await getDiscussionSummary(req.params.topic);
+
+    if (!summary) {
+      return res.status(404).json({ error: 'Discussion not found' });
+    }
+
+    res.setHeader('Content-Type', 'application/json');
+    res.setHeader('Content-Disposition', `attachment; filename="${sanitizeFilename(req.params.topic)}-summary.json"`);
+    res.send(JSON.stringify(summary, null, 2));
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+app.get('/api/discussions/:topic/export.csv', async (req, res) => {
+  try {
+    const discussion = await getDiscussionByTopic(req.params.topic);
+    if (!discussion) {
+      return res.status(404).json({ error: 'Discussion not found' });
+    }
+
+    const questions = await getQuestions(req.params.topic);
+    const headers = [
+      'discussion_topic',
+      'question_id',
+      'question_text',
+      'question_type',
+      'question_created_at',
+      'response_id',
+      'respondent',
+      'response_value',
+      'response_created_at',
+    ];
+    const rows = questions.flatMap(question => {
+      const votes = question.votes || [];
+      if (votes.length === 0) {
+        return [[
+          discussion.topic,
+          question.id,
+          question.text,
+          question.type,
+          question.created_at,
+          '',
+          '',
+          '',
+          '',
+        ]];
+      }
+
+      return votes.map(vote => [
+        discussion.topic,
+        question.id,
+        question.text,
+        question.type,
+        question.created_at,
+        vote.id,
+        vote.pseudonym || 'Anonymous',
+        parseStoredVoteValue(vote.value),
+        vote.created_at,
+      ]);
+    });
+
+    const csv = [
+      headers.map(escapeCsv).join(','),
+      ...rows.map(row => row.map(escapeCsv).join(',')),
+    ].join('\n');
+
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader('Content-Disposition', `attachment; filename="${sanitizeFilename(req.params.topic)}-responses.csv"`);
+    res.send(csv);
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'Server error' });


### PR DESCRIPTION
Adds a read-only post-discussion summary page with counts, top consensus, top divisive items, numerical stats, and written-response synthesis.
Adds CSV and JSON export endpoints plus discussion-page links for exporting or opening the summary.
The server reuses existing question/vote data and supports optional LLM synthesis when `ENABLE_LLM_SYNTHESIS=true` and `OPENAI_API_KEY` are configured.
Validated with `node --check server.js`, `npx eslint server.js client/src/App.jsx client/src/DiscussionPage.jsx client/src/SummaryPage.jsx`, and `npm run build`.
