### PR TITLE
Fix discussion creation, vote toggle, Vite env, and submission edge cases

### DIFF
--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -49,9 +49,12 @@ const AGREEMENT_SCALE = [
 ];
 
 // In production the client is served by the same server it talks to, so we
-// default to a same-origin connection. Set REACT_APP_SOCKET_URL only when the
+// default to a same-origin connection. Set VITE_SOCKET_URL only when the
 // client runs on a different origin than the API (e.g. `vite` dev server).
-const SOCKET_URL = process.env.REACT_APP_SOCKET_URL || undefined;
+// Use import.meta.env (Vite's mechanism) rather than process.env: `process` is
+// not defined in the browser, so an unreplaced process.env.* reference throws
+// at module load and blanks the page.
+const SOCKET_URL = import.meta.env.VITE_SOCKET_URL || undefined;
 
 const socket = io(SOCKET_URL);
 
@@ -292,18 +295,20 @@ const DiscussionPage = () => {
 
     // Emits a question to the server. When force is false the server may reply
     // with a 'similarQuestion' event instead of adding it; when true it adds
-    // regardless of near-duplicates.
+    // regardless of near-duplicates. The form is reset only once the server acks
+    // that the question was actually added, so a near-duplicate bounce (or an
+    // error) leaves the user's draft intact for them to edit or re-post.
     const submitQuestion = (question, force) => {
         try {
-            socket.emit('addQuestion', topic, question, force);
-
-            // Reset form
-            setNewQuestion('');
-            setQuestionType(QuestionTypes.AGREEMENT);
-            setMinValue(0);
-            setMaxValue(100);
-            // Clear any previous errors
             setError(null);
+            socket.emit('addQuestion', topic, question, force, (resp) => {
+                if (resp && resp.added) {
+                    setNewQuestion('');
+                    setQuestionType(QuestionTypes.AGREEMENT);
+                    setMinValue(0);
+                    setMaxValue(100);
+                }
+            });
         } catch (error) {
             console.error('Error emitting addQuestion event:', error);
             setError('Failed to add question. Please try again.');
@@ -806,10 +811,15 @@ const OpenEndedQuestion = ({ question, userVote, handleVote, userId, handleRespo
                     />
                     <button
                         onClick={() => {
-                            console.log('Submitting open-ended response:', response);
-                            handleVote(question.id, response);
+                            const trimmed = response.trim();
+                            if (trimmed === '') {
+                                return;
+                            }
+                            console.log('Submitting open-ended response:', trimmed);
+                            handleVote(question.id, trimmed);
                         }}
-                        className="px-4 py-2 bg-primary text-white rounded hover:bg-opacity-90 transition duration-300 mb-4"
+                        disabled={response.trim() === ''}
+                        className="px-4 py-2 bg-primary text-white rounded hover:bg-opacity-90 transition duration-300 mb-4 disabled:opacity-50"
                     >
                         {userVote ? 'Update Response' : 'Submit Response'}
                     </button>

--- a/client/src/HomePage.jsx
+++ b/client/src/HomePage.jsx
@@ -3,9 +3,12 @@ import { Link, useNavigate } from 'react-router-dom';
 import io from 'socket.io-client';
 
 // In production the client is served by the same server it talks to, so we
-// default to a same-origin connection. Set REACT_APP_SOCKET_URL only when the
+// default to a same-origin connection. Set VITE_SOCKET_URL only when the
 // client runs on a different origin than the API (e.g. `vite` dev server).
-const SOCKET_URL = process.env.REACT_APP_SOCKET_URL || undefined;
+// Use import.meta.env (Vite's mechanism) rather than process.env: `process` is
+// not defined in the browser, so an unreplaced process.env.* reference throws
+// at module load and blanks the page.
+const SOCKET_URL = import.meta.env.VITE_SOCKET_URL || undefined;
 
 const HomePage = () => {
     const [discussions, setDiscussions] = useState([]);
@@ -39,20 +42,23 @@ const HomePage = () => {
     }, []);
 
     const handleCreateDiscussion = async () => {
-        if (newDiscussion.trim() !== '') {
-            const discussionId = newDiscussion.toLowerCase().replace(/\s+/g, '-');
+        const topic = newDiscussion.trim();
+        if (topic !== '') {
             try {
                 const response = await fetch('/api/discussions', {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
                     },
-                    body: JSON.stringify({ topic: newDiscussion }),
+                    body: JSON.stringify({ topic }),
                 });
                 if (!response.ok) {
                     throw new Error('Failed to create discussion');
                 }
-                navigate(`/discussion/${discussionId}`);
+                // Navigate using the same topic the server stored (and that the
+                // existing-discussions links use), so the creator lands in the
+                // discussion they just created rather than a separate slugified one.
+                navigate(`/discussion/${encodeURIComponent(topic)}`);
             } catch (error) {
                 console.error('Error creating discussion:', error);
             }

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -9,6 +9,15 @@ import { defineConfig } from 'vite';
 // leaking into the browser bundle.
 dotenv.config({ path: path.resolve(__dirname, '../.env') });
 
+// Backward compatibility: older split-origin deployments set the socket URL via
+// REACT_APP_SOCKET_URL. import.meta.env only exposes VITE_-prefixed vars, so map
+// the legacy name onto the new one (when the new one isn't already set) — Vite's
+// env loader reads VITE_-prefixed entries from process.env, so those deployments
+// keep working without a rename. New deployments should use VITE_SOCKET_URL.
+if (!process.env.VITE_SOCKET_URL && process.env.REACT_APP_SOCKET_URL) {
+  process.env.VITE_SOCKET_URL = process.env.REACT_APP_SOCKET_URL;
+}
+
 export default defineConfig({
   plugins: [react()],
   // The root .env lives one level up from this client directory, so point Vite's

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -3,20 +3,17 @@ import dotenv from 'dotenv';
 import path from 'path';
 import { defineConfig } from 'vite';
 
-// Load environment variables from the root .env file
+// Load the root .env into process.env so the dev-server `port` below can read
+// PORT. Client-facing config is exposed via import.meta.env instead (see
+// envDir): Vite natively injects VITE_-prefixed vars, with no `process` global
+// leaking into the browser bundle.
 dotenv.config({ path: path.resolve(__dirname, '../.env') });
-
-// Filter out only the variables starting with REACT_APP_
-const envWithPrefix = {};
-for (const key in process.env) {
-  if (key.startsWith('REACT_APP_')) {
-    envWithPrefix[`process.env.${key}`] = JSON.stringify(process.env[key]);
-  }
-}
 
 export default defineConfig({
   plugins: [react()],
-  define: envWithPrefix,
+  // The root .env lives one level up from this client directory, so point Vite's
+  // env loader there to pick up VITE_-prefixed variables.
+  envDir: path.resolve(__dirname, '..'),
   root: path.resolve(__dirname, ''),
   build: {
     outDir: path.resolve(__dirname, '../dist'),

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -73,8 +73,10 @@ redeploy. Nothing else to do.
 - **Region.** The web service and database must share a region (`oregon` here)
   so they talk over Render's private network. Change both together if you move.
 - **No URL config needed.** The client connects same-origin, so you do not need
-  to set `REACT_APP_SOCKET_URL` or `CLIENT_URL`. (`CLIENT_URL` only matters if
-  you later serve the frontend from a different origin.)
+  to set `VITE_SOCKET_URL` or `CLIENT_URL`. (`VITE_SOCKET_URL` only matters if
+  you serve the frontend from a different origin than the API; the legacy
+  `REACT_APP_SOCKET_URL` name is still honored for backward compatibility.
+  `CLIENT_URL` only matters in that split-origin case too.)
 - **Custom domain.** Add it under the web service's **Settings → Custom Domains**;
   Render provisions TLS automatically.
 - **Scaling past one instance.** If you ever outgrow a single instance, Socket.IO

--- a/server.js
+++ b/server.js
@@ -386,14 +386,22 @@ io.on('connection', (socket) => {
     emitPresence(roomToLeave);
   });
 
-  socket.on('addQuestion', async (topic, question, force) => {
+  socket.on('addQuestion', async (topic, question, force, ack) => {
     console.log('Received addQuestion event');
     console.log('topic:', topic);
     console.log('question:', question);
 
+    // Report the outcome back to the submitter so the client only clears its
+    // draft once the question is actually added — not when it's bounced as a
+    // near-duplicate or fails.
+    const reply = (result) => {
+      if (typeof ack === 'function') ack(result);
+    };
+
     try {
       if (await isDiscussionLocked(topic)) {
         socket.emit('error', { message: 'This discussion is locked.' });
+        reply({ added: false, reason: 'locked' });
         return;
       }
 
@@ -403,6 +411,7 @@ io.on('connection', (socket) => {
         const similar = await findSimilarQuestion(topic, question.text);
         if (similar) {
           socket.emit('similarQuestion', { candidate: similar, question });
+          reply({ added: false, reason: 'similar' });
           return;
         }
       }
@@ -412,9 +421,11 @@ io.on('connection', (socket) => {
       const updatedQuestions = await getQuestions(topic);
       console.log('Retrieved updated questions:', updatedQuestions);
       io.to(topic).emit('questions', updatedQuestions);
+      reply({ added: true });
     } catch (error) {
       console.error('Error adding question:', error);
       socket.emit('error', { message: 'Failed to add question' });
+      reply({ added: false, reason: 'error' });
     }
   });
 
@@ -908,7 +919,10 @@ async function addVote(questionId, vote, userId, pseudonym) {
           'UPDATE votes SET value = $1, pseudonym = $2 WHERE id = $3',
           [JSON.stringify(vote), pseudonym, existingVote.id]
         );
-      } else if (existingVote.value === vote) {
+      } else if (existingVote.value === vote && questionType === 'Agreement') {
+        // Agreement votes toggle: re-selecting your current option undoes it.
+        // This must stay scoped to Agreement — for Open Ended, re-submitting the
+        // same text means "keep it", not "delete it".
         console.log('Voting for a option they already voted for');
         await client.query(
           'DELETE FROM votes WHERE id = $1',


### PR DESCRIPTION
Fixes several bugs found while reviewing the app: creating a discussion now navigates to the same topic the server stored (instead of a separately-slugified URL that split it into two rooms), and the Agreement undo-on-re-vote toggle is scoped to Agreement so re-submitting an unchanged Open Ended response keeps it rather than deleting it. The client reads `import.meta.env.VITE_SOCKET_URL` instead of `process.env.*`, removing a `process is not defined` crash that could blank the page in production. Empty Open Ended responses are now guarded, and the new-question form clears only once the server acks the add — preserving the draft when a near-duplicate is bounced (`addQuestion` now returns an outcome ack). Verified with `vite build` (bundle is `process`-free), ESLint, and `node --check`.

Deploy notes: client and server must deploy together (new `ack` arg on the `addQuestion` socket event), and any socket-URL override env var must be renamed `REACT_APP_SOCKET_URL` → `VITE_SOCKET_URL` (not needed for same-origin production).

🤖 Generated with [Claude Code](https://claude.com/claude-code)