### PR TITLE
Add isolated, flag-gated opinion clustering view

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link, Route, BrowserRouter as Router, Routes } from 'react-router-dom';
+import ClusterPage from './ClusterPage';
 import DiscussionPage from './DiscussionPage';
 import HomePage from './HomePage';
 import SummaryPage from './SummaryPage';
@@ -18,6 +19,7 @@ const App = () => {
                         <Route path="/" element={<HomePage />} />
                         <Route path="/discussion/:topic" element={<DiscussionPage />} />
                         <Route path="/discussion/:topic/summary" element={<SummaryPage />} />
+                        <Route path="/discussion/:topic/clusters" element={<ClusterPage />} />
                     </Routes>
                 </main>
             </div>

--- a/client/src/ClusterPage.jsx
+++ b/client/src/ClusterPage.jsx
@@ -27,9 +27,9 @@ const StanceBar = ({ agree, unsure, disagree }) => {
                 {agree > 0 && <div className="bg-green-500" style={{ width: pct(agree) }} title={`Agree: ${agree}`} />}
             </div>
             <div className="flex gap-x-3 mt-1 text-xs text-gray-500">
-                <span>Agree: {agree}</span>
-                <span>Unsure: {unsure}</span>
                 <span>Disagree: {disagree}</span>
+                <span>Unsure: {unsure}</span>
+                <span>Agree: {agree}</span>
             </div>
         </div>
     );

--- a/client/src/ClusterPage.jsx
+++ b/client/src/ClusterPage.jsx
@@ -164,7 +164,7 @@ const ClusterPage = () => {
     return (
         <div className="max-w-5xl mx-auto mt-10 px-4">
             <div className="mb-6">
-                <Link to={`/discussion/${topic}`} className="text-primary hover:underline">
+                <Link to={`/discussion/${encodeURIComponent(topic)}`} className="text-primary hover:underline">
                     Back to discussion
                 </Link>
                 <div className="flex items-center gap-3 mt-3 mb-2">

--- a/client/src/ClusterPage.jsx
+++ b/client/src/ClusterPage.jsx
@@ -102,14 +102,17 @@ const StatementList = ({ title, subtitle, items, clusters, emptyText }) => (
                         <div className="text-gray-900 font-medium">{st.text}</div>
                         <div className="flex flex-wrap gap-2 mt-2">
                             {st.clusterMeans.map((mean, idx) => {
+                                const didVote = !st.clusterVoters || st.clusterVoters[idx] > 0;
                                 const lean = leaning(mean);
+                                const label = didVote ? lean.label : "Didn't vote";
+                                const dot = didVote ? lean.dot : 'bg-gray-200';
                                 return (
                                     <span
                                         key={idx}
                                         className="inline-flex items-center text-xs px-2 py-1 rounded-full bg-gray-50 border border-gray-200 text-gray-700"
                                     >
-                                        <span className={`inline-block w-2 h-2 rounded-full mr-1.5 ${lean.dot}`} />
-                                        {clusters[idx] ? clusters[idx].label : `Group ${idx + 1}`}: {lean.label}
+                                        <span className={`inline-block w-2 h-2 rounded-full mr-1.5 ${dot}`} />
+                                        {clusters[idx] ? clusters[idx].label : `Group ${idx + 1}`}: {label}
                                     </span>
                                 );
                             })}

--- a/client/src/ClusterPage.jsx
+++ b/client/src/ClusterPage.jsx
@@ -1,0 +1,222 @@
+import PropTypes from 'prop-types';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+
+// Map a mean agreement score (-2..2) to a human-readable leaning. Always
+// returns a text label so the view stays readable without relying on color.
+function leaning(mean) {
+    if (mean >= 1.2) return { label: 'Strongly agrees', tone: 'text-green-700', dot: 'bg-green-600' };
+    if (mean >= 0.3) return { label: 'Agrees', tone: 'text-green-600', dot: 'bg-green-400' };
+    if (mean > -0.3) return { label: 'Mixed / unsure', tone: 'text-gray-600', dot: 'bg-gray-400' };
+    if (mean > -1.2) return { label: 'Disagrees', tone: 'text-red-600', dot: 'bg-red-400' };
+    return { label: 'Strongly disagrees', tone: 'text-red-700', dot: 'bg-red-600' };
+}
+
+// A compact agree/unsure/disagree bar for one statement within a group.
+const StanceBar = ({ agree, unsure, disagree }) => {
+    const total = agree + unsure + disagree;
+    if (total === 0) {
+        return null;
+    }
+    const pct = n => `${(n / total) * 100}%`;
+    return (
+        <div className="mt-2">
+            <div className="flex w-full h-2.5 rounded-full overflow-hidden bg-gray-200">
+                {disagree > 0 && <div className="bg-red-500" style={{ width: pct(disagree) }} title={`Disagree: ${disagree}`} />}
+                {unsure > 0 && <div className="bg-gray-400" style={{ width: pct(unsure) }} title={`Unsure: ${unsure}`} />}
+                {agree > 0 && <div className="bg-green-500" style={{ width: pct(agree) }} title={`Agree: ${agree}`} />}
+            </div>
+            <div className="flex gap-x-3 mt-1 text-xs text-gray-500">
+                <span>Agree: {agree}</span>
+                <span>Unsure: {unsure}</span>
+                <span>Disagree: {disagree}</span>
+            </div>
+        </div>
+    );
+};
+
+StanceBar.propTypes = {
+    agree: PropTypes.number.isRequired,
+    unsure: PropTypes.number.isRequired,
+    disagree: PropTypes.number.isRequired,
+};
+
+const GroupCard = ({ cluster }) => (
+    <section className="bg-white shadow rounded-lg p-6">
+        <div className="flex items-baseline justify-between mb-4">
+            <h3 className="text-xl font-bold text-gray-900">{cluster.label}</h3>
+            <span className="text-sm text-gray-500">
+                {cluster.size} {cluster.size === 1 ? 'person' : 'people'}
+            </span>
+        </div>
+        <p className="text-sm text-gray-500 mb-3">What sets this group apart:</p>
+        {cluster.definingStatements.length === 0 ? (
+            <p className="text-sm text-gray-400">Not enough votes to characterize this group.</p>
+        ) : (
+            <ul className="space-y-4">
+                {cluster.definingStatements.map(st => {
+                    const lean = leaning(st.mean);
+                    return (
+                        <li key={st.id} className="border-b border-gray-100 last:border-0 pb-3 last:pb-0">
+                            <div className="text-gray-900">{st.text}</div>
+                            <div className={`text-sm font-semibold mt-1 ${lean.tone}`}>
+                                <span className={`inline-block w-2 h-2 rounded-full mr-1.5 ${lean.dot}`} />
+                                {lean.label}
+                                <span className="font-normal text-gray-400"> · {st.voters} voted</span>
+                            </div>
+                            <StanceBar agree={st.agree} unsure={st.unsure} disagree={st.disagree} />
+                        </li>
+                    );
+                })}
+            </ul>
+        )}
+    </section>
+);
+
+GroupCard.propTypes = {
+    cluster: PropTypes.shape({
+        label: PropTypes.string.isRequired,
+        size: PropTypes.number.isRequired,
+        definingStatements: PropTypes.arrayOf(PropTypes.shape({
+            id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+            text: PropTypes.string.isRequired,
+            mean: PropTypes.number.isRequired,
+            agree: PropTypes.number.isRequired,
+            unsure: PropTypes.number.isRequired,
+            disagree: PropTypes.number.isRequired,
+            voters: PropTypes.number.isRequired,
+        })).isRequired,
+    }).isRequired,
+};
+
+const StatementList = ({ title, subtitle, items, clusters, emptyText }) => (
+    <section className="bg-white shadow rounded-lg p-6">
+        <h2 className="text-2xl font-bold mb-1 text-gray-800">{title}</h2>
+        <p className="text-sm text-gray-500 mb-4">{subtitle}</p>
+        {items.length === 0 ? (
+            <p className="text-sm text-gray-400">{emptyText}</p>
+        ) : (
+            <ol className="space-y-4">
+                {items.map(st => (
+                    <li key={st.id} className="border-b border-gray-100 last:border-0 pb-4 last:pb-0">
+                        <div className="text-gray-900 font-medium">{st.text}</div>
+                        <div className="flex flex-wrap gap-2 mt-2">
+                            {st.clusterMeans.map((mean, idx) => {
+                                const lean = leaning(mean);
+                                return (
+                                    <span
+                                        key={idx}
+                                        className="inline-flex items-center text-xs px-2 py-1 rounded-full bg-gray-50 border border-gray-200 text-gray-700"
+                                    >
+                                        <span className={`inline-block w-2 h-2 rounded-full mr-1.5 ${lean.dot}`} />
+                                        {clusters[idx] ? clusters[idx].label : `Group ${idx + 1}`}: {lean.label}
+                                    </span>
+                                );
+                            })}
+                        </div>
+                    </li>
+                ))}
+            </ol>
+        )}
+    </section>
+);
+
+StatementList.propTypes = {
+    title: PropTypes.string.isRequired,
+    subtitle: PropTypes.string.isRequired,
+    items: PropTypes.array.isRequired,
+    clusters: PropTypes.array.isRequired,
+    emptyText: PropTypes.string.isRequired,
+};
+
+const ClusterPage = () => {
+    const { topic } = useParams();
+    const [data, setData] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    const encodedTopic = encodeURIComponent(topic);
+
+    const load = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const response = await fetch(`/api/discussions/${encodedTopic}/clusters`);
+            if (!response.ok) {
+                throw new Error('Failed to load clusters');
+            }
+            setData(await response.json());
+        } catch (err) {
+            console.error('Error loading clusters:', err);
+            setError('Could not load opinion groups.');
+        } finally {
+            setLoading(false);
+        }
+    }, [encodedTopic]);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    return (
+        <div className="max-w-5xl mx-auto mt-10 px-4">
+            <div className="mb-6">
+                <Link to={`/discussion/${topic}`} className="text-primary hover:underline">
+                    Back to discussion
+                </Link>
+                <div className="flex items-center gap-3 mt-3 mb-2">
+                    <h1 className="text-4xl font-bold text-gray-800">Opinion Groups</h1>
+                    <span className="px-2 py-1 text-xs font-semibold rounded-full bg-amber-100 text-amber-800">
+                        Experimental
+                    </span>
+                </div>
+                <p className="text-gray-600">{topic}</p>
+            </div>
+
+            {loading && <p className="text-gray-600">Finding opinion groups…</p>}
+            {error && <p className="text-red-600">{error}</p>}
+
+            {!loading && !error && data && !data.eligible && (
+                <div className="bg-white shadow rounded-lg p-6 text-gray-600">
+                    {data.reason}
+                </div>
+            )}
+
+            {!loading && !error && data && data.eligible && (
+                <>
+                    <p className="text-gray-700 mb-6">
+                        {data.participantCount} participants split into{' '}
+                        <span className="font-semibold">{data.k} opinion groups</span> based on how they
+                        voted across {data.statementCount} agreement statements. Groups are found
+                        automatically and updated as votes come in.
+                    </p>
+
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+                        {data.clusters.map(cluster => (
+                            <GroupCard key={cluster.id} cluster={cluster} />
+                        ))}
+                    </div>
+
+                    <div className="grid grid-cols-1 gap-6">
+                        <StatementList
+                            title="Common Ground"
+                            subtitle="Statements every group leans the same way on — the shared starting points."
+                            items={data.bridging}
+                            clusters={data.clusters}
+                            emptyText="No statements yet where all groups agree."
+                        />
+                        <StatementList
+                            title="Most Divisive"
+                            subtitle="Statements where the groups disagree most sharply."
+                            items={data.divisive}
+                            clusters={data.clusters}
+                            emptyText="Not enough votes to find divisive statements."
+                        />
+                    </div>
+                </>
+            )}
+        </div>
+    );
+};
+
+export default ClusterPage;

--- a/client/src/ClusterPage.jsx
+++ b/client/src/ClusterPage.jsx
@@ -184,35 +184,45 @@ const ClusterPage = () => {
 
             {!loading && !error && data && data.eligible && (
                 <>
-                    <p className="text-gray-700 mb-6">
-                        {data.participantCount} participants split into{' '}
-                        <span className="font-semibold">{data.k} opinion groups</span> based on how they
-                        voted across {data.statementCount} agreement statements. Groups are found
-                        automatically and updated as votes come in.
-                    </p>
+                    {data.k === 1 ? (
+                        <p className="text-gray-700 mb-6">
+                            All {data.participantCount} participants fall into a single group — they
+                            voted alike across {data.statementCount} agreement statements, so there
+                            are no distinct opinion camps yet. This usually means broad consensus.
+                        </p>
+                    ) : (
+                        <p className="text-gray-700 mb-6">
+                            {data.participantCount} participants split into{' '}
+                            <span className="font-semibold">{data.k} opinion groups</span> based on how
+                            they voted across {data.statementCount} agreement statements. Groups are
+                            found automatically and updated as votes come in.
+                        </p>
+                    )}
 
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+                    <div className={`grid grid-cols-1 ${data.k > 1 ? 'md:grid-cols-2' : ''} gap-6 mb-8`}>
                         {data.clusters.map(cluster => (
                             <GroupCard key={cluster.id} cluster={cluster} />
                         ))}
                     </div>
 
-                    <div className="grid grid-cols-1 gap-6">
-                        <StatementList
-                            title="Common Ground"
-                            subtitle="Statements every group leans the same way on — the shared starting points."
-                            items={data.bridging}
-                            clusters={data.clusters}
-                            emptyText="No statements yet where all groups agree."
-                        />
-                        <StatementList
-                            title="Most Divisive"
-                            subtitle="Statements where the groups disagree most sharply."
-                            items={data.divisive}
-                            clusters={data.clusters}
-                            emptyText="Not enough votes to find divisive statements."
-                        />
-                    </div>
+                    {data.k > 1 && (
+                        <div className="grid grid-cols-1 gap-6">
+                            <StatementList
+                                title="Common Ground"
+                                subtitle="Statements every group leans the same way on — the shared starting points."
+                                items={data.bridging}
+                                clusters={data.clusters}
+                                emptyText="No statements yet where all groups agree."
+                            />
+                            <StatementList
+                                title="Most Divisive"
+                                subtitle="Statements where the groups disagree most sharply."
+                                items={data.divisive}
+                                clusters={data.clusters}
+                                emptyText="Not enough votes to find divisive statements."
+                            />
+                        </div>
+                    )}
                 </>
             )}
         </div>

--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -78,6 +78,10 @@ const DiscussionPage = () => {
     const [discussionState, setDiscussionState] = useState({ locked: false, hasModerator: false });
     const [similarPrompt, setSimilarPrompt] = useState(null);
     const [adminLinkCopied, setAdminLinkCopied] = useState(false);
+    // Experimental "opinion groups" view, hidden behind a ?clusters=1 flag so it
+    // can be evaluated on a real discussion without exposing it to everyone. Once
+    // enabled it's remembered per browser so the link survives navigation.
+    const [showClusters, setShowClusters] = useState(false);
 
     const isAdmin = !!adminToken;
     const { locked } = discussionState;
@@ -125,6 +129,21 @@ const DiscussionPage = () => {
             setAdminToken(localStorage.getItem(storageKey));
         } catch (e) {
             console.warn('Failed to read admin token:', e);
+        }
+    }, [topic]);
+
+    useEffect(() => {
+        const key = 'convora_show_clusters';
+        try {
+            const params = new URLSearchParams(window.location.search);
+            if (params.get('clusters') === '1') {
+                localStorage.setItem(key, '1');
+                setShowClusters(true);
+                return;
+            }
+            setShowClusters(localStorage.getItem(key) === '1');
+        } catch (e) {
+            console.warn('Failed to read clusters flag:', e);
         }
     }, [topic]);
 
@@ -522,6 +541,14 @@ const DiscussionPage = () => {
                 >
                     View Summary
                 </Link>
+                {showClusters && (
+                    <Link
+                        to={`/discussion/${topic}/clusters`}
+                        className="bg-amber-600 text-white py-2 px-4 rounded hover:bg-amber-700 transition duration-300"
+                    >
+                        Opinion Groups
+                    </Link>
+                )}
                 <a
                     href={`/api/discussions/${encodeURIComponent(topic)}/export.csv`}
                     className="bg-primary text-white py-2 px-4 rounded hover:bg-opacity-90 transition duration-300"

--- a/clustering.js
+++ b/clustering.js
@@ -338,8 +338,19 @@ function analyzeClusters(questions) {
   }
 
   if (!best) {
-    const { assignments } = kmeans(matrix, 2, rng);
-    best = { k: 2, assignments, score: silhouette(matrix, assignments, 2) };
+    // No candidate k >= 2 produced distinct groups: every participant votes
+    // essentially alike. Report a single consensus group rather than
+    // fabricating a second, empty one (which would leave the UI claiming "2
+    // opinion groups" with an empty Group B).
+    return buildClusterReport(
+      statements,
+      participants,
+      matrix,
+      voted,
+      new Array(participants.length).fill(0),
+      1,
+      null
+    );
   }
 
   return buildClusterReport(statements, participants, matrix, voted, best.assignments, best.k, best.score);

--- a/clustering.js
+++ b/clustering.js
@@ -373,12 +373,22 @@ function analyzeClusters(questions) {
   const rng = makeRng(0x9e3779b9);
   const maxK = Math.min(MAX_CLUSTERS, participants.length - 1);
   let best = null;
+  let suppressedSplit = false;
   for (let k = 2; k <= maxK; k += 1) {
     const { assignments } = kmeans(matrix, k, rng);
     const sizes = new Array(k).fill(0);
     assignments.forEach(a => { sizes[a] += 1; });
-    // Skip splits that collapsed (an empty cluster) or produced a singleton —
-    // both would either misreport k or expose an individual's votes.
+    const distinctGroups = sizes.filter(sz => sz > 0).length;
+    const hasSingleton = sizes.some(sz => sz > 0 && sz < MIN_GROUP_SIZE);
+    // A genuine k-way split (no empty clusters) where a group is too small to
+    // anonymize: a distinct minority exists but can't be shown. Remember this
+    // so we don't later mislabel it as consensus.
+    if (distinctGroups === k && hasSingleton) {
+      suppressedSplit = true;
+      continue;
+    }
+    // Otherwise skip splits that collapsed into fewer real groups (an empty
+    // cluster), which are not a true k-way division.
     if (sizes.some(sz => sz < MIN_GROUP_SIZE)) {
       continue;
     }
@@ -389,10 +399,20 @@ function analyzeClusters(questions) {
   }
 
   if (!best) {
-    // No candidate k >= 2 produced distinct groups: every participant votes
-    // essentially alike. Report a single consensus group rather than
-    // fabricating a second, empty one (which would leave the UI claiming "2
-    // opinion groups" with an empty Group B).
+    if (suppressedSplit) {
+      // A distinct camp existed but the smaller group was a singleton, so we
+      // can't show groups without identifying that person. Report a suppressed
+      // state rather than implying broad consensus.
+      return {
+        eligible: false,
+        suppressed: true,
+        reason: 'A distinct minority view is present, but the smaller group is too small to show without identifying individuals, so opinion groups are hidden for this discussion.',
+        participantCount: participants.length,
+        statementCount: statements.length,
+      };
+    }
+    // No distinct groups at all: every participant votes essentially alike.
+    // Report a single consensus group rather than fabricating an empty second.
     return buildClusterReport(
       statements,
       participants,

--- a/clustering.js
+++ b/clustering.js
@@ -1,0 +1,348 @@
+// Participant opinion clustering for Convora ("opinion groups" view).
+//
+// This module is deliberately self-contained and dependency-free: it consumes
+// the plain question objects that getQuestions() already returns and produces a
+// JSON-serializable analysis. It performs no database access and is wired into
+// the server through a single read-only endpoint, so the experimental clusters
+// view can be added or removed without touching the voting flow.
+//
+// Approach (a lightweight take on the Pol.is model):
+//   1. Build a participant x statement matrix from Agreement votes.
+//   2. Cluster participants with k-means (k chosen by silhouette score).
+//   3. For each group, surface the statements that most define it, plus
+//      "bridging" statements every group agrees on and the most divisive ones.
+
+const AGREEMENT_SCORES = {
+  'Strongly Disagree': -2,
+  Disagree: -1,
+  Unsure: 0,
+  Agree: 1,
+  'Strongly Agree': 2,
+};
+
+// Below these thresholds clustering is noise rather than signal.
+const MIN_PARTICIPANTS = 4;
+const MIN_STATEMENTS = 2;
+const MAX_CLUSTERS = 5;
+
+// Deterministic PRNG (mulberry32). The same votes must always yield the same
+// groups, since people reload this view and compare it over time.
+function makeRng(seed) {
+  let a = seed >>> 0;
+  return function next() {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function distSq(a, b) {
+  let sum = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    const d = a[i] - b[i];
+    sum += d * d;
+  }
+  return sum;
+}
+
+// Build the participant x statement matrix from Agreement questions only.
+//   matrix[i][j] = participant i's score on statement j (0 when they didn't vote)
+//   voted[i][j]  = whether participant i actually cast a vote on statement j
+function buildVoteMatrix(questions) {
+  const statements = questions
+    .filter(q => q.type === 'Agreement')
+    .map(q => ({ id: q.id, text: q.text }));
+
+  // userId -> Map(statementId -> score). votes arrive ordered by id, so a later
+  // entry overwrites an earlier one and the latest vote wins.
+  const byUser = new Map();
+  questions
+    .filter(q => q.type === 'Agreement')
+    .forEach(q => {
+      (q.votes || []).forEach(v => {
+        if (!v.userId || !(v.value in AGREEMENT_SCORES)) {
+          return;
+        }
+        if (!byUser.has(v.userId)) {
+          byUser.set(v.userId, new Map());
+        }
+        byUser.get(v.userId).set(q.id, AGREEMENT_SCORES[v.value]);
+      });
+    });
+
+  const participants = [...byUser.keys()];
+  const matrix = [];
+  const voted = [];
+  participants.forEach(uid => {
+    const scores = byUser.get(uid);
+    matrix.push(statements.map(s => (scores.has(s.id) ? scores.get(s.id) : 0)));
+    voted.push(statements.map(s => (scores.has(s.id) ? 1 : 0)));
+  });
+
+  return { statements, participants, matrix, voted };
+}
+
+function kmeans(matrix, k, rng) {
+  const n = matrix.length;
+  const dim = matrix[0].length;
+
+  // k-means++ seeding for stable, well-spread initial centroids.
+  const centroids = [matrix[Math.floor(rng() * n)].slice()];
+  while (centroids.length < k) {
+    const dists = matrix.map(p => Math.min(...centroids.map(c => distSq(p, c))));
+    const total = dists.reduce((s, d) => s + d, 0);
+    let idx;
+    if (total === 0) {
+      idx = Math.floor(rng() * n);
+    } else {
+      let r = rng() * total;
+      idx = 0;
+      while (idx < n - 1 && r > dists[idx]) {
+        r -= dists[idx];
+        idx += 1;
+      }
+    }
+    centroids.push(matrix[idx].slice());
+  }
+
+  const assignments = new Array(n).fill(-1);
+  for (let iter = 0; iter < 100; iter += 1) {
+    let changed = false;
+    for (let i = 0; i < n; i += 1) {
+      let best = 0;
+      let bestD = Infinity;
+      for (let c = 0; c < k; c += 1) {
+        const d = distSq(matrix[i], centroids[c]);
+        if (d < bestD) {
+          bestD = d;
+          best = c;
+        }
+      }
+      if (assignments[i] !== best) {
+        assignments[i] = best;
+        changed = true;
+      }
+    }
+
+    const sums = Array.from({ length: k }, () => new Array(dim).fill(0));
+    const counts = new Array(k).fill(0);
+    for (let i = 0; i < n; i += 1) {
+      counts[assignments[i]] += 1;
+      const row = matrix[i];
+      const target = sums[assignments[i]];
+      for (let d = 0; d < dim; d += 1) {
+        target[d] += row[d];
+      }
+    }
+    for (let c = 0; c < k; c += 1) {
+      if (counts[c] === 0) {
+        // Reseed an emptied cluster so k stays meaningful.
+        centroids[c] = matrix[Math.floor(rng() * n)].slice();
+      } else {
+        for (let d = 0; d < dim; d += 1) {
+          centroids[c][d] = sums[c][d] / counts[c];
+        }
+      }
+    }
+
+    if (!changed) {
+      break;
+    }
+  }
+
+  return { assignments };
+}
+
+// Mean silhouette score in [-1, 1]; higher means tighter, better-separated
+// clusters. Used to pick k. O(n^2) but group discussions are small.
+function silhouette(matrix, assignments, k) {
+  const n = matrix.length;
+  const groups = Array.from({ length: k }, () => []);
+  assignments.forEach((a, i) => groups[a].push(i));
+
+  let total = 0;
+  for (let i = 0; i < n; i += 1) {
+    const own = groups[assignments[i]];
+    if (own.length <= 1) {
+      continue; // singleton contributes 0
+    }
+    let a = 0;
+    for (const j of own) {
+      if (j !== i) {
+        a += Math.sqrt(distSq(matrix[i], matrix[j]));
+      }
+    }
+    a /= own.length - 1;
+
+    let b = Infinity;
+    for (let c = 0; c < k; c += 1) {
+      if (c === assignments[i] || groups[c].length === 0) {
+        continue;
+      }
+      let d = 0;
+      for (const j of groups[c]) {
+        d += Math.sqrt(distSq(matrix[i], matrix[j]));
+      }
+      d /= groups[c].length;
+      if (d < b) {
+        b = d;
+      }
+    }
+    if (b !== Infinity) {
+      total += (b - a) / Math.max(a, b);
+    }
+  }
+  return total / n;
+}
+
+// Per-statement breakdown for a set of participant indices, counting only
+// people who actually voted on that statement.
+function statementStats(memberIdxs, j, matrix, voted) {
+  let sum = 0;
+  let voters = 0;
+  let agree = 0;
+  let disagree = 0;
+  let unsure = 0;
+  for (const i of memberIdxs) {
+    if (!voted[i][j]) {
+      continue;
+    }
+    voters += 1;
+    const s = matrix[i][j];
+    sum += s;
+    if (s > 0) {
+      agree += 1;
+    } else if (s < 0) {
+      disagree += 1;
+    } else {
+      unsure += 1;
+    }
+  }
+  return {
+    mean: voters ? sum / voters : 0,
+    voters,
+    agree,
+    disagree,
+    unsure,
+    noVote: memberIdxs.length - voters,
+  };
+}
+
+function buildClusterReport(statements, participants, matrix, voted, assignments, k, score) {
+  const allIdx = participants.map((_, i) => i);
+  const members = Array.from({ length: k }, () => []);
+  assignments.forEach((a, i) => members[a].push(i));
+
+  // Each group: the statements where it diverges most from everyone else.
+  const clusters = members.map((memberIdxs, c) => {
+    const rest = allIdx.filter(i => assignments[i] !== c);
+    const perStatement = statements.map((s, j) => {
+      const inStats = statementStats(memberIdxs, j, matrix, voted);
+      const restStats = statementStats(rest, j, matrix, voted);
+      return {
+        id: s.id,
+        text: s.text,
+        mean: inStats.mean,
+        agree: inStats.agree,
+        disagree: inStats.disagree,
+        unsure: inStats.unsure,
+        noVote: inStats.noVote,
+        voters: inStats.voters,
+        divergence: Math.abs(inStats.mean - restStats.mean),
+      };
+    });
+    const definingStatements = perStatement
+      .filter(st => st.voters > 0)
+      .sort((a, b) => b.divergence - a.divergence)
+      .slice(0, 5);
+    return {
+      id: c,
+      label: `Group ${String.fromCharCode(65 + c)}`,
+      size: memberIdxs.length,
+      definingStatements,
+    };
+  });
+
+  // Statement-level view across groups, for bridging vs. divisive lists.
+  const perStatement = statements.map((s, j) => {
+    const clusterMeans = members.map(memberIdxs => statementStats(memberIdxs, j, matrix, voted).mean);
+    const overall = statementStats(allIdx, j, matrix, voted);
+    const opinions = clusterMeans.filter(m => Math.abs(m) > 0.1);
+    const signs = new Set(opinions.map(m => Math.sign(m)));
+    return {
+      id: s.id,
+      text: s.text,
+      clusterMeans,
+      overallMean: overall.mean,
+      voters: overall.voters,
+      agree: overall.agree,
+      disagree: overall.disagree,
+      // Every group that has an opinion leans the same way.
+      allGroupsAgree: opinions.length > 0 && signs.size === 1,
+      minMagnitude: Math.min(...clusterMeans.map(m => Math.abs(m))),
+      spread: Math.max(...clusterMeans) - Math.min(...clusterMeans),
+      direction: overall.mean > 0 ? 'agree' : overall.mean < 0 ? 'disagree' : 'split',
+    };
+  });
+
+  const bridging = perStatement
+    .filter(st => st.allGroupsAgree && st.voters >= 2 && Math.abs(st.overallMean) >= 0.5)
+    .sort((a, b) => b.minMagnitude - a.minMagnitude || a.spread - b.spread)
+    .slice(0, 5);
+
+  const divisive = perStatement
+    .filter(st => st.voters >= 2)
+    .sort((a, b) => b.spread - a.spread)
+    .slice(0, 5);
+
+  return {
+    eligible: true,
+    k,
+    silhouette: score,
+    participantCount: participants.length,
+    statementCount: statements.length,
+    clusters,
+    bridging,
+    divisive,
+  };
+}
+
+// Main entry point. Returns either {eligible: false, reason} when there isn't
+// enough data, or the full cluster analysis.
+function analyzeClusters(questions) {
+  const { statements, participants, matrix, voted } = buildVoteMatrix(questions);
+
+  if (participants.length < MIN_PARTICIPANTS || statements.length < MIN_STATEMENTS) {
+    return {
+      eligible: false,
+      reason: `Opinion groups need at least ${MIN_PARTICIPANTS} participants and ${MIN_STATEMENTS} agreement statements with votes. So far there are ${participants.length} participant(s) and ${statements.length} agreement statement(s).`,
+      participantCount: participants.length,
+      statementCount: statements.length,
+    };
+  }
+
+  const rng = makeRng(0x9e3779b9);
+  const maxK = Math.min(MAX_CLUSTERS, participants.length - 1);
+  let best = null;
+  for (let k = 2; k <= maxK; k += 1) {
+    const { assignments } = kmeans(matrix, k, rng);
+    if (new Set(assignments).size < k) {
+      continue; // collapsed into fewer real groups; skip
+    }
+    const score = silhouette(matrix, assignments, k);
+    if (!best || score > best.score) {
+      best = { k, assignments, score };
+    }
+  }
+
+  if (!best) {
+    const { assignments } = kmeans(matrix, 2, rng);
+    best = { k: 2, assignments, score: silhouette(matrix, assignments, 2) };
+  }
+
+  return buildClusterReport(statements, participants, matrix, voted, best.assignments, best.k, best.score);
+}
+
+module.exports = { analyzeClusters, buildVoteMatrix, AGREEMENT_SCORES };

--- a/clustering.js
+++ b/clustering.js
@@ -25,6 +25,12 @@ const MIN_PARTICIPANTS = 4;
 const MIN_STATEMENTS = 2;
 const MAX_CLUSTERS = 5;
 
+// A group counts as leaning (rather than neutral) only once its mean agreement
+// passes this magnitude. Matches the UI's "Agrees/Disagrees" vs "Mixed/unsure"
+// boundary, so a statement is never called common ground while a group is shown
+// as undecided.
+const COMMON_GROUND_LEAN = 0.3;
+
 // Deterministic PRNG (mulberry32). The same votes must always yield the same
 // groups, since people reload this view and compare it over time.
 function makeRng(seed) {
@@ -282,22 +288,27 @@ function buildClusterReport(statements, participants, matrix, voted, assignments
     // that actually voted: common ground requires every group to have weighed
     // in, and spread/magnitude are measured over voting groups only.
     const everyGroupVoted = clusterStats.every(cs => cs.voters > 0);
+    const votedGroups = clusterVoters.filter(v => v > 0).length;
     const votedMeans = clusterMeans.filter((m, i) => clusterVoters[i] > 0);
-    const opinions = votedMeans.filter(m => Math.abs(m) > 0.1);
-    const signs = new Set(opinions.map(m => Math.sign(m)));
+
+    // Common ground requires every group to actually lean the same way. A group
+    // that voted but is collectively neutral (|mean| < COMMON_GROUND_LEAN) does
+    // not count as agreement and must not be dropped, otherwise a statement gets
+    // labeled common ground while the UI shows that group as "Mixed / unsure".
+    const allAgree = votedMeans.length > 0 && votedMeans.every(m => m >= COMMON_GROUND_LEAN);
+    const allDisagree = votedMeans.length > 0 && votedMeans.every(m => m <= -COMMON_GROUND_LEAN);
 
     return {
       id: s.id,
       text: s.text,
       clusterMeans,
       clusterVoters,
+      votedGroups,
       overallMean: overall.mean,
       voters: overall.voters,
       agree: overall.agree,
       disagree: overall.disagree,
-      // Common ground: every group voted, and every group with a clear opinion
-      // leans the same way.
-      allGroupsAgree: everyGroupVoted && opinions.length > 0 && signs.size === 1,
+      allGroupsAgree: everyGroupVoted && (allAgree || allDisagree),
       minMagnitude: votedMeans.length > 0 ? Math.min(...votedMeans.map(m => Math.abs(m))) : 0,
       spread: votedMeans.length >= 2 ? Math.max(...votedMeans) - Math.min(...votedMeans) : 0,
       direction: overall.mean > 0 ? 'agree' : overall.mean < 0 ? 'disagree' : 'split',
@@ -309,8 +320,10 @@ function buildClusterReport(statements, participants, matrix, voted, assignments
     .sort((a, b) => b.minMagnitude - a.minMagnitude || a.spread - b.spread)
     .slice(0, 5);
 
+  // Divisive needs at least two groups that actually voted, so a single group's
+  // internal spread can't masquerade as cross-group disagreement.
   const divisive = perStatement
-    .filter(st => st.voters >= 2)
+    .filter(st => st.voters >= 2 && st.votedGroups >= 2)
     .sort((a, b) => b.spread - a.spread)
     .slice(0, 5);
 

--- a/clustering.js
+++ b/clustering.js
@@ -51,26 +51,31 @@ function distSq(a, b) {
 //   matrix[i][j] = participant i's score on statement j (0 when they didn't vote)
 //   voted[i][j]  = whether participant i actually cast a vote on statement j
 function buildVoteMatrix(questions) {
-  const statements = questions
-    .filter(q => q.type === 'Agreement')
-    .map(q => ({ id: q.id, text: q.text }));
+  const agreementQuestions = questions.filter(q => q.type === 'Agreement');
 
   // userId -> Map(statementId -> score). votes arrive ordered by id, so a later
   // entry overwrites an earlier one and the latest vote wins.
   const byUser = new Map();
-  questions
-    .filter(q => q.type === 'Agreement')
-    .forEach(q => {
-      (q.votes || []).forEach(v => {
-        if (!v.userId || !(v.value in AGREEMENT_SCORES)) {
-          return;
-        }
-        if (!byUser.has(v.userId)) {
-          byUser.set(v.userId, new Map());
-        }
-        byUser.get(v.userId).set(q.id, AGREEMENT_SCORES[v.value]);
-      });
+  const votedStatementIds = new Set();
+  agreementQuestions.forEach(q => {
+    (q.votes || []).forEach(v => {
+      if (!v.userId || !(v.value in AGREEMENT_SCORES)) {
+        return;
+      }
+      if (!byUser.has(v.userId)) {
+        byUser.set(v.userId, new Map());
+      }
+      byUser.get(v.userId).set(q.id, AGREEMENT_SCORES[v.value]);
+      votedStatementIds.add(q.id);
     });
+  });
+
+  // Only statements that actually received at least one valid vote count: an
+  // empty Agreement question must not inflate the statement total (which gates
+  // eligibility) or add a dead all-zero dimension to the clustering.
+  const statements = agreementQuestions
+    .filter(q => votedStatementIds.has(q.id))
+    .map(q => ({ id: q.id, text: q.text }));
 
   const participants = [...byUser.keys()];
   const matrix = [];

--- a/clustering.js
+++ b/clustering.js
@@ -272,22 +272,34 @@ function buildClusterReport(statements, participants, matrix, voted, assignments
 
   // Statement-level view across groups, for bridging vs. divisive lists.
   const perStatement = statements.map((s, j) => {
-    const clusterMeans = members.map(memberIdxs => statementStats(memberIdxs, j, matrix, voted).mean);
+    const clusterStats = members.map(memberIdxs => statementStats(memberIdxs, j, matrix, voted));
+    const clusterMeans = clusterStats.map(cs => cs.mean);
+    const clusterVoters = clusterStats.map(cs => cs.voters);
     const overall = statementStats(allIdx, j, matrix, voted);
-    const opinions = clusterMeans.filter(m => Math.abs(m) > 0.1);
+
+    // A cluster with no votes also has mean 0, which is indistinguishable from
+    // a neutral "Unsure". So all cross-group metrics consider only the groups
+    // that actually voted: common ground requires every group to have weighed
+    // in, and spread/magnitude are measured over voting groups only.
+    const everyGroupVoted = clusterStats.every(cs => cs.voters > 0);
+    const votedMeans = clusterMeans.filter((m, i) => clusterVoters[i] > 0);
+    const opinions = votedMeans.filter(m => Math.abs(m) > 0.1);
     const signs = new Set(opinions.map(m => Math.sign(m)));
+
     return {
       id: s.id,
       text: s.text,
       clusterMeans,
+      clusterVoters,
       overallMean: overall.mean,
       voters: overall.voters,
       agree: overall.agree,
       disagree: overall.disagree,
-      // Every group that has an opinion leans the same way.
-      allGroupsAgree: opinions.length > 0 && signs.size === 1,
-      minMagnitude: Math.min(...clusterMeans.map(m => Math.abs(m))),
-      spread: Math.max(...clusterMeans) - Math.min(...clusterMeans),
+      // Common ground: every group voted, and every group with a clear opinion
+      // leans the same way.
+      allGroupsAgree: everyGroupVoted && opinions.length > 0 && signs.size === 1,
+      minMagnitude: votedMeans.length > 0 ? Math.min(...votedMeans.map(m => Math.abs(m))) : 0,
+      spread: votedMeans.length >= 2 ? Math.max(...votedMeans) - Math.min(...votedMeans) : 0,
       direction: overall.mean > 0 ? 'agree' : overall.mean < 0 ? 'disagree' : 'split',
     };
   });

--- a/clustering.js
+++ b/clustering.js
@@ -297,6 +297,11 @@ function buildClusterReport(statements, participants, matrix, voted, assignments
     // labeled common ground while the UI shows that group as "Mixed / unsure".
     const allAgree = votedMeans.length > 0 && votedMeans.every(m => m >= COMMON_GROUND_LEAN);
     const allDisagree = votedMeans.length > 0 && votedMeans.every(m => m <= -COMMON_GROUND_LEAN);
+    // Genuine division needs groups leaning in opposite directions, not merely
+    // agreeing with different intensity. This also keeps a statement from ever
+    // landing in both the common-ground and divisive lists.
+    const groupsOppose = votedMeans.some(m => m >= COMMON_GROUND_LEAN)
+      && votedMeans.some(m => m <= -COMMON_GROUND_LEAN);
 
     return {
       id: s.id,
@@ -304,6 +309,7 @@ function buildClusterReport(statements, participants, matrix, voted, assignments
       clusterMeans,
       clusterVoters,
       votedGroups,
+      groupsOppose,
       overallMean: overall.mean,
       voters: overall.voters,
       agree: overall.agree,
@@ -320,10 +326,11 @@ function buildClusterReport(statements, participants, matrix, voted, assignments
     .sort((a, b) => b.minMagnitude - a.minMagnitude || a.spread - b.spread)
     .slice(0, 5);
 
-  // Divisive needs at least two groups that actually voted, so a single group's
-  // internal spread can't masquerade as cross-group disagreement.
+  // Divisive needs at least two groups that actually voted AND leaning in
+  // opposite directions, so neither a single group's internal spread nor a
+  // same-direction intensity gap can masquerade as cross-group disagreement.
   const divisive = perStatement
-    .filter(st => st.voters >= 2 && st.votedGroups >= 2)
+    .filter(st => st.voters >= 2 && st.votedGroups >= 2 && st.groupsOppose)
     .sort((a, b) => b.spread - a.spread)
     .slice(0, 5);
 

--- a/clustering.js
+++ b/clustering.js
@@ -25,6 +25,12 @@ const MIN_PARTICIPANTS = 4;
 const MIN_STATEMENTS = 2;
 const MAX_CLUSTERS = 5;
 
+// Smallest group we'll surface. A one-person cluster's per-statement stats
+// would expose that individual's exact votes, undoing the anonymity that
+// getQuestions() otherwise provides, so k-splits producing singletons are
+// rejected (we fall back to a coarser k, ultimately a single consensus group).
+const MIN_GROUP_SIZE = 2;
+
 // A group counts as leaning (rather than neutral) only once its mean agreement
 // passes this magnitude. Matches the UI's "Agrees/Disagrees" vs "Mixed/unsure"
 // boundary, so a statement is never called common ground while a group is shown
@@ -261,11 +267,15 @@ function buildClusterReport(statements, participants, matrix, voted, assignments
         unsure: inStats.unsure,
         noVote: inStats.noVote,
         voters: inStats.voters,
+        restVoters: restStats.voters,
         divergence: Math.abs(inStats.mean - restStats.mean),
       };
     });
+    // A statement only defines a group when both that group and the rest of the
+    // room have actually voted on it — otherwise divergence just reflects who
+    // happened to weigh in (the rest's no-votes read as a neutral 0 mean).
     const definingStatements = perStatement
-      .filter(st => st.voters > 0)
+      .filter(st => st.voters > 0 && st.restVoters > 0)
       .sort((a, b) => b.divergence - a.divergence)
       .slice(0, 5);
     return {
@@ -365,8 +375,12 @@ function analyzeClusters(questions) {
   let best = null;
   for (let k = 2; k <= maxK; k += 1) {
     const { assignments } = kmeans(matrix, k, rng);
-    if (new Set(assignments).size < k) {
-      continue; // collapsed into fewer real groups; skip
+    const sizes = new Array(k).fill(0);
+    assignments.forEach(a => { sizes[a] += 1; });
+    // Skip splits that collapsed (an empty cluster) or produced a singleton —
+    // both would either misreport k or expose an individual's votes.
+    if (sizes.some(sz => sz < MIN_GROUP_SIZE)) {
+      continue;
     }
     const score = silhouette(matrix, assignments, k);
     if (!best || score > best.score) {

--- a/server.js
+++ b/server.js
@@ -1737,7 +1737,10 @@ app.get('/api/discussions/:topic/clusters', async (req, res) => {
       return res.status(404).json({ error: 'Discussion not found' });
     }
 
-    const questions = await getQuestions(req.params.topic);
+    // Opt into raw user ids: clustering groups participants by stable id, and
+    // this runs server-side only — the response carries aggregate cluster data
+    // (sizes, per-statement means), never individual ids.
+    const questions = await getQuestions(req.params.topic, { includeUserIds: true });
     const analysis = analyzeClusters(questions);
 
     res.json({

--- a/server.js
+++ b/server.js
@@ -8,6 +8,7 @@ const path = require('path');
 const crypto = require('crypto');
 const bodyParser = require('body-parser');
 const cors = require('cors');
+const { analyzeClusters } = require('./clustering');
 
 const app = express();
 const server = http.createServer(app);
@@ -1058,6 +1059,33 @@ app.get('/api/discussions/:topic/summary', async (req, res) => {
     }
 
     res.json(summary);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// Read-only opinion clustering ("opinion groups"). Computes participant groups
+// from existing Agreement votes on the fly; writes nothing. Kept separate from
+// the summary so the experimental clusters view can be removed cleanly.
+app.get('/api/discussions/:topic/clusters', async (req, res) => {
+  try {
+    const discussion = await getDiscussionByTopic(req.params.topic);
+    if (!discussion) {
+      return res.status(404).json({ error: 'Discussion not found' });
+    }
+
+    const questions = await getQuestions(req.params.topic);
+    const analysis = analyzeClusters(questions);
+
+    res.json({
+      discussion: {
+        id: discussion.id,
+        topic: discussion.topic,
+        createdAt: discussion.created_at,
+      },
+      ...analysis,
+    });
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'Server error' });


### PR DESCRIPTION
Adds a Pol.is-style **Opinion Groups** view that clusters participants by their Agreement votes (k-means with silhouette-chosen k), then surfaces each group's defining statements alongside cross-group common ground and most-divisive statements. The feature is deliberately self-contained: all clustering math lives in a new dependency-free `clustering.js`, exposed through one read-only endpoint (`GET /api/discussions/:topic/clusters`) that writes nothing and needs no schema changes, and rendered by a new `ClusterPage`. The entry-point button in `DiscussionPage` is hidden behind a `?clusters=1` flag (remembered per browser) so it can be evaluated on real discussions without exposing it to everyone, and the whole feature can be removed without touching the voting flow.

Verified end-to-end against a throwaway Postgres + the live server: seeded two opinion camps and confirmed the endpoint finds the groups, identifies common ground, and flags divisive statements; ineligible (too little data) and unknown-topic (404) paths also behave correctly. `npm run build` and ESLint both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New opinion groups feature analyzes and visualizes participant agreement patterns in discussions
  * Added dedicated page to explore opinion clusters with key consensus and divisive statements highlighted
  * New navigation option to access opinion groups view
  * Visual indicators display agreement distribution within each group

<!-- end of auto-generated comment: release notes by coderabbit.ai -->