### PR TITLE
[codex] Add canonical discussion slugs

### DIFF
--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -4,6 +4,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import io from 'socket.io-client';
 import { QRCodeSVG } from 'qrcode.react';
 import { getIdentity, regeneratePseudonym } from './identity';
+import { slugifyTopic } from './slugs';
 
 const VERSION = '0.1.8';
 console.log('Convora version:', VERSION);
@@ -58,6 +59,8 @@ const socket = io(SOCKET_URL);
 const DiscussionPage = () => {
     const { topic } = useParams();
     const navigate = useNavigate();
+    const discussionSlug = slugifyTopic(topic);
+    const [discussion, setDiscussion] = useState(null);
     const [questions, setQuestions] = useState([]);
     const [newQuestion, setNewQuestion] = useState('');
     const [questionType, setQuestionType] = useState(QuestionTypes.AGREEMENT);
@@ -81,10 +84,13 @@ const DiscussionPage = () => {
 
     const isAdmin = !!adminToken;
     const { locked } = discussionState;
+    const discussionTitle = discussion?.topic || topic;
 
-    const shareUrl = typeof window !== 'undefined' ? window.location.href : '';
+    const shareUrl = typeof window !== 'undefined'
+        ? `${window.location.origin}/discussion/${discussionSlug}`
+        : '';
     const adminUrl = typeof window !== 'undefined' && adminToken
-        ? `${window.location.origin}${window.location.pathname}?admin=${adminToken}`
+        ? `${window.location.origin}/discussion/${discussionSlug}?admin=${adminToken}`
         : '';
 
     const handleCopyLink = async () => {
@@ -106,11 +112,17 @@ const DiscussionPage = () => {
         setPseudonym(identity.pseudonym);
     }, []);
 
+    useEffect(() => {
+        if (topic !== discussionSlug) {
+            navigate(`/discussion/${discussionSlug}`, { replace: true });
+        }
+    }, [topic, discussionSlug, navigate]);
+
     // Adopt the moderator token for this topic: an ?admin=<token> URL param
     // (shared admin link) takes precedence and is then persisted and stripped
     // from the URL; otherwise fall back to a previously stored token.
     useEffect(() => {
-        const storageKey = `convora_admin_${topic}`;
+        const storageKey = `convora_admin_${discussionSlug}`;
         try {
             const params = new URLSearchParams(window.location.search);
             const fromUrl = params.get('admin');
@@ -126,7 +138,7 @@ const DiscussionPage = () => {
         } catch (e) {
             console.warn('Failed to read admin token:', e);
         }
-    }, [topic]);
+    }, [discussionSlug]);
 
     const handleRegeneratePseudonym = () => {
         const updated = regeneratePseudonym();
@@ -134,10 +146,10 @@ const DiscussionPage = () => {
     };
 
     const handleClaimModerator = () => {
-        socket.emit('claimModerator', topic, (resp) => {
+        socket.emit('claimModerator', discussionSlug, (resp) => {
             if (resp && resp.success) {
                 try {
-                    localStorage.setItem(`convora_admin_${topic}`, resp.token);
+                    localStorage.setItem(`convora_admin_${discussionSlug}`, resp.token);
                 } catch (e) {
                     console.warn('Failed to store admin token:', e);
                 }
@@ -149,15 +161,15 @@ const DiscussionPage = () => {
     };
 
     const handleToggleLock = () => {
-        socket.emit('setLocked', topic, !locked, adminToken);
+        socket.emit('setLocked', discussionSlug, !locked, adminToken);
     };
 
     const handleDeleteQuestion = (questionId) => {
-        socket.emit('deleteQuestion', topic, questionId, adminToken);
+        socket.emit('deleteQuestion', discussionSlug, questionId, adminToken);
     };
 
     const handleTogglePin = (questionId, pinned) => {
-        socket.emit('setPinned', topic, questionId, !pinned, adminToken);
+        socket.emit('setPinned', discussionSlug, questionId, !pinned, adminToken);
     };
 
     const handleCopyAdminLink = async () => {
@@ -183,12 +195,12 @@ const DiscussionPage = () => {
                 headers: {
                     'Content-Type': 'application/json',
                 },
-                body: JSON.stringify({ originalTopic: topic, newTopic: newTopicName }),
+                body: JSON.stringify({ originalTopic: discussionSlug, newTopic: newTopicName }),
             });
 
             if (response.ok) {
                 const result = await response.json();
-                navigate(`/discussion/${result.newTopic}`);
+                navigate(`/discussion/${result.newSlug}`);
             } else {
                 const errorData = await response.json();
                 setError(`Failed to duplicate discussion: ${errorData.error}`);
@@ -240,8 +252,9 @@ const DiscussionPage = () => {
     }, []);
 
     useEffect(() => {
-        console.log('Current topic:', topic);
-        socket.emit('joinDiscussion', topic);
+        console.log('Current topic:', discussionSlug);
+        socket.emit('joinDiscussion', discussionSlug);
+        socket.on('discussion', setDiscussion);
         socket.on('questions', handleQuestionsUpdate);
         socket.on('presence', setPresence);
         socket.on('discussionState', setDiscussionState);
@@ -249,13 +262,14 @@ const DiscussionPage = () => {
         return () => {
             // Leave the room so the server stops counting this client toward the
             // discussion's presence once the page unmounts (e.g. navigating home).
-            socket.emit('leaveDiscussion', topic);
+            socket.emit('leaveDiscussion', discussionSlug);
+            socket.off('discussion', setDiscussion);
             socket.off('questions', handleQuestionsUpdate);
             socket.off('presence', setPresence);
             socket.off('discussionState', setDiscussionState);
             socket.off('similarQuestion', setSimilarPrompt);
         };
-    }, [topic, handleQuestionsUpdate]);
+    }, [discussionSlug, handleQuestionsUpdate]);
 
     const handleAddQuestion = () => {
         console.log('Inside handleAddQuestion');
@@ -295,7 +309,7 @@ const DiscussionPage = () => {
     // regardless of near-duplicates.
     const submitQuestion = (question, force) => {
         try {
-            socket.emit('addQuestion', topic, question, force);
+            socket.emit('addQuestion', discussionSlug, question, force);
 
             // Reset form
             setNewQuestion('');
@@ -319,7 +333,7 @@ const DiscussionPage = () => {
 
     const handleVote = (questionId, value) => {
         console.log('Voting:', questionId, value);
-        socket.emit('vote', topic, questionId, value, userId, pseudonym);
+        socket.emit('vote', discussionSlug, questionId, value, userId, pseudonym);
         setSliderValues(prev => ({ ...prev, [questionId]: undefined }));
     };
 
@@ -327,7 +341,7 @@ const DiscussionPage = () => {
     // (a participant can only delete their own).
     const handleDeleteVote = (questionId, voteId) => {
         console.log('Deleting vote:', questionId, voteId);
-        socket.emit('deleteVote', topic, voteId, userId);
+        socket.emit('deleteVote', discussionSlug, voteId, userId);
     };
 
     const handleSliderChange = (questionId, value) => {
@@ -335,7 +349,7 @@ const DiscussionPage = () => {
     };
 
     const handleResponseVote = (responseId) => {
-        socket.emit('toggleResponseVote', topic, responseId, userId);
+        socket.emit('toggleResponseVote', discussionSlug, responseId, userId);
     };
 
     const sortQuestions = (questions) => {
@@ -483,7 +497,7 @@ const DiscussionPage = () => {
 
     return (
         <div className="max-w-4xl mx-auto mt-10 px-4">
-            <h1 className="text-4xl font-bold mb-2 text-center text-gray-800">Discussion: {topic}</h1>
+            <h1 className="text-4xl font-bold mb-2 text-center text-gray-800">Discussion: {discussionTitle}</h1>
 
             {/* Participant identity + live presence */}
             <div className="mb-8 text-center text-sm text-gray-600">
@@ -517,19 +531,19 @@ const DiscussionPage = () => {
                     Duplicate Discussion
                 </button>
                 <Link
-                    to={`/discussion/${topic}/summary`}
+                    to={`/discussion/${discussionSlug}/summary`}
                     className="bg-gray-800 text-white py-2 px-4 rounded hover:bg-gray-700 transition duration-300"
                 >
                     View Summary
                 </Link>
                 <a
-                    href={`/api/discussions/${encodeURIComponent(topic)}/export.csv`}
+                    href={`/api/discussions/${encodeURIComponent(discussionSlug)}/export.csv`}
                     className="bg-primary text-white py-2 px-4 rounded hover:bg-opacity-90 transition duration-300"
                 >
                     Export CSV
                 </a>
                 <a
-                    href={`/api/discussions/${encodeURIComponent(topic)}/export.json`}
+                    href={`/api/discussions/${encodeURIComponent(discussionSlug)}/export.json`}
                     className="bg-secondary text-white py-2 px-4 rounded hover:bg-opacity-90 transition duration-300"
                 >
                     Export JSON

--- a/client/src/HomePage.jsx
+++ b/client/src/HomePage.jsx
@@ -40,7 +40,6 @@ const HomePage = () => {
 
     const handleCreateDiscussion = async () => {
         if (newDiscussion.trim() !== '') {
-            const discussionId = newDiscussion.toLowerCase().replace(/\s+/g, '-');
             try {
                 const response = await fetch('/api/discussions', {
                     method: 'POST',
@@ -52,7 +51,8 @@ const HomePage = () => {
                 if (!response.ok) {
                     throw new Error('Failed to create discussion');
                 }
-                navigate(`/discussion/${discussionId}`);
+                const discussion = await response.json();
+                navigate(`/discussion/${discussion.slug}`);
             } catch (error) {
                 console.error('Error creating discussion:', error);
             }
@@ -82,7 +82,7 @@ const HomePage = () => {
                 {discussions.map(discussion => (
                     <Link
                         key={discussion.id}
-                        to={`/discussion/${discussion.topic}`}
+                        to={`/discussion/${discussion.slug}`}
                         className="bg-white shadow-lg rounded-lg p-6 hover:shadow-xl transition duration-300"
                     >
                         <h2 className="text-xl font-semibold mb-2">{discussion.topic}</h2>

--- a/client/src/SummaryPage.jsx
+++ b/client/src/SummaryPage.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { slugifyTopic } from './slugs';
 
 const AGREEMENT_OPTIONS = [
     'Strongly Disagree',
@@ -33,12 +34,20 @@ function formatDate(value) {
 
 const SummaryPage = () => {
     const { topic } = useParams();
+    const navigate = useNavigate();
+    const discussionSlug = slugifyTopic(topic);
     const [summary, setSummary] = useState(null);
     const [loading, setLoading] = useState(true);
     const [synthesisLoading, setSynthesisLoading] = useState(false);
     const [error, setError] = useState(null);
 
-    const encodedTopic = encodeURIComponent(topic);
+    const encodedTopic = encodeURIComponent(discussionSlug);
+
+    useEffect(() => {
+        if (topic !== discussionSlug) {
+            navigate(`/discussion/${discussionSlug}/summary`, { replace: true });
+        }
+    }, [topic, discussionSlug, navigate]);
 
     const loadSummary = useCallback(async ({ llm = false } = {}) => {
         if (llm) {
@@ -77,7 +86,7 @@ const SummaryPage = () => {
         return (
             <div className="max-w-5xl mx-auto mt-10 px-4">
                 <p className="text-red-600 mb-4">{error}</p>
-                <Link to={`/discussion/${topic}`} className="text-primary hover:underline">Back to discussion</Link>
+                <Link to={`/discussion/${discussionSlug}`} className="text-primary hover:underline">Back to discussion</Link>
             </div>
         );
     }
@@ -89,7 +98,7 @@ const SummaryPage = () => {
     return (
         <div className="max-w-5xl mx-auto mt-10 px-4">
             <div className="mb-6">
-                <Link to={`/discussion/${topic}`} className="text-primary hover:underline">
+                <Link to={`/discussion/${discussionSlug}`} className="text-primary hover:underline">
                     Back to discussion
                 </Link>
                 <h1 className="text-4xl font-bold mt-3 mb-2 text-gray-800">Summary: {summary.discussion.topic}</h1>

--- a/client/src/SummaryPage.jsx
+++ b/client/src/SummaryPage.jsx
@@ -44,12 +44,42 @@ const SummaryPage = () => {
     const encodedTopic = encodeURIComponent(discussionSlug);
 
     useEffect(() => {
-        if (topic !== discussionSlug) {
-            navigate(`/discussion/${discussionSlug}/summary`, { replace: true });
-        }
+        if (topic === discussionSlug) return undefined;
+
+        let cancelled = false;
+        const search = typeof window !== 'undefined' ? window.location.search : '';
+        const fallback = `/discussion/${discussionSlug}/summary${search}`;
+
+        const resolveRoute = async () => {
+            try {
+                const response = await fetch(`/api/discussions/resolve/${encodeURIComponent(topic)}`);
+                if (response.ok) {
+                    const data = await response.json();
+                    if (!cancelled && data?.slug) {
+                        navigate(`/discussion/${data.slug}/summary${search}`, { replace: true });
+                        return;
+                    }
+                }
+            } catch (error) {
+                console.warn('Failed to resolve summary route:', error);
+            }
+
+            if (!cancelled) {
+                navigate(fallback, { replace: true });
+            }
+        };
+
+        resolveRoute();
+        return () => {
+            cancelled = true;
+        };
     }, [topic, discussionSlug, navigate]);
 
     const loadSummary = useCallback(async ({ llm = false } = {}) => {
+        if (topic !== discussionSlug) {
+            return;
+        }
+
         if (llm) {
             setSynthesisLoading(true);
         } else {
@@ -72,7 +102,7 @@ const SummaryPage = () => {
             setLoading(false);
             setSynthesisLoading(false);
         }
-    }, [encodedTopic]);
+    }, [encodedTopic, topic, discussionSlug]);
 
     useEffect(() => {
         loadSummary();

--- a/client/src/slugs.js
+++ b/client/src/slugs.js
@@ -1,0 +1,10 @@
+export function slugifyTopic(value) {
+    return String(value || 'discussion')
+        .trim()
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .slice(0, 80) || 'discussion';
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,9 +5,11 @@ import { fixupConfigRules } from "@eslint/compat";
 
 
 export default [
+  { ignores: ["dist/**", "node_modules/**"] },
   {files: ["**/*.{js,mjs,cjs,jsx}"]},
   { languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } } },
   {languageOptions: { globals: {...globals.browser, ...globals.node} }},
+  { settings: { react: { version: "detect" } } },
   pluginJs.configs.recommended,
   ...fixupConfigRules(pluginReactConfig),
 ];

--- a/schema.sql
+++ b/schema.sql
@@ -8,11 +8,13 @@
 CREATE TABLE IF NOT EXISTS discussions (
   id         SERIAL PRIMARY KEY,
   topic      TEXT NOT NULL,
+  slug       TEXT,
   created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
 );
 
 -- discussions.topic is made unique by migrateUniqueDiscussionTopics() after
 -- any duplicate rows from older deployments have been collapsed.
+-- discussions.slug is populated and made unique by migrateDiscussionSlugs().
 
 CREATE TABLE IF NOT EXISTS questions (
   id            SERIAL PRIMARY KEY,

--- a/server.js
+++ b/server.js
@@ -100,6 +100,14 @@ function titleFromSlug(slug) {
     .join(' ') || 'Discussion';
 }
 
+function suffixSlug(baseSlug, suffix) {
+  if (suffix <= 1) {
+    return baseSlug;
+  }
+  const suffixText = `-${suffix}`;
+  return `${baseSlug.slice(0, 80 - suffixText.length)}${suffixText}`;
+}
+
 function escapeCsv(value) {
   if (value === null || value === undefined) {
     return '';
@@ -968,15 +976,23 @@ app.get('/api/discussions/:id', async (req, res) => {
 // Database functions
 async function getOrCreateDiscussion(db, topic) {
   const displayTopic = formatTopicTitle(topic);
-  const slug = slugifyTopic(displayTopic);
-  const result = await db.query(
-    `INSERT INTO discussions (topic, slug)
-     VALUES ($1, $2)
-     ON CONFLICT (slug) DO UPDATE SET slug = EXCLUDED.slug
-     RETURNING id, topic, slug`,
-    [displayTopic, slug]
-  );
-  return result.rows[0];
+  const baseSlug = slugifyTopic(displayTopic);
+
+  for (let suffix = 1; suffix <= 1000; suffix += 1) {
+    const slug = suffixSlug(baseSlug, suffix);
+    const result = await db.query(
+      `INSERT INTO discussions (topic, slug)
+       VALUES ($1, $2)
+       ON CONFLICT (slug) DO NOTHING
+       RETURNING id, topic, slug`,
+      [displayTopic, slug]
+    );
+    if (result.rows.length > 0) {
+      return result.rows[0];
+    }
+  }
+
+  throw new Error(`Could not create a unique slug for discussion topic: ${displayTopic}`);
 }
 
 async function getOrCreateDiscussionForSlug(db, slug) {
@@ -1165,8 +1181,7 @@ async function migrateDiscussionSlugs() {
       let slug = baseSlug;
       let suffix = 2;
       while (usedSlugs.has(slug)) {
-        const suffixText = `-${suffix}`;
-        slug = `${baseSlug.slice(0, 80 - suffixText.length)}${suffixText}`;
+        slug = suffixSlug(baseSlug, suffix);
         suffix += 1;
       }
 

--- a/server.js
+++ b/server.js
@@ -1320,21 +1320,36 @@ async function migrateDiscussionSlugs() {
     await client.query('ALTER TABLE discussions ADD COLUMN IF NOT EXISTS slug TEXT');
 
     const result = await client.query('SELECT id, topic, slug FROM discussions ORDER BY id');
+    const rows = result.rows
+      .map(row => ({
+        ...row,
+        baseSlug: getMigrationBaseSlug(row),
+        priority: isSlugShapedLegacyTitle(row.topic) ? 0 : 1,
+      }))
+      .sort((a, b) => a.priority - b.priority || a.id - b.id);
     const usedSlugs = new Set();
+    const assignments = [];
 
-    for (const row of result.rows) {
-      const baseSlug = row.slug ? slugifyTopic(row.slug) : slugifyTopic(row.topic);
-      let slug = baseSlug;
+    for (const row of rows) {
+      let slug = row.baseSlug;
       let suffix = 2;
       while (usedSlugs.has(slug)) {
-        slug = suffixSlug(baseSlug, suffix);
+        slug = suffixSlug(row.baseSlug, suffix);
         suffix += 1;
       }
 
       usedSlugs.add(slug);
-      if (row.slug !== slug) {
-        await client.query('UPDATE discussions SET slug = $1 WHERE id = $2', [slug, row.id]);
-      }
+      assignments.push({ id: row.id, currentSlug: row.slug, slug });
+    }
+
+    const changedAssignments = assignments.filter(row => row.currentSlug !== row.slug);
+    const tempPrefix = `__convora_slug_migration_${process.pid}_`;
+    for (const row of changedAssignments) {
+      await client.query('UPDATE discussions SET slug = $1 WHERE id = $2', [`${tempPrefix}${row.id}`, row.id]);
+    }
+
+    for (const row of changedAssignments) {
+      await client.query('UPDATE discussions SET slug = $1 WHERE id = $2', [row.slug, row.id]);
     }
 
     await client.query(`
@@ -1353,6 +1368,18 @@ async function migrateDiscussionSlugs() {
   } finally {
     client.release();
   }
+}
+
+function isSlugShapedLegacyTitle(topic) {
+  const title = formatTopicTitle(topic);
+  return title === slugifyTopic(title);
+}
+
+function getMigrationBaseSlug(row) {
+  if (isSlugShapedLegacyTitle(row.topic)) {
+    return slugifyTopic(row.topic);
+  }
+  return row.slug ? slugifyTopic(row.slug) : slugifyTopic(row.topic);
 }
 
 // Table for upvotes on individual open-ended responses. One row per

--- a/server.js
+++ b/server.js
@@ -74,6 +74,33 @@ function sanitizeFilename(value) {
     .slice(0, 80) || 'discussion';
 }
 
+function slugifyTopic(value) {
+  return String(value || 'discussion')
+    .trim()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80) || 'discussion';
+}
+
+function formatTopicTitle(value) {
+  const title = String(value || '').trim().replace(/\s+/g, ' ');
+  if (title) {
+    return title;
+  }
+  return 'Discussion';
+}
+
+function titleFromSlug(slug) {
+  return slugifyTopic(slug)
+    .split('-')
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ') || 'Discussion';
+}
+
 function escapeCsv(value) {
   if (value === null || value === undefined) {
     return '';
@@ -300,6 +327,7 @@ function buildSummary(discussion, questions, synthesis) {
     discussion: {
       id: discussion.id,
       topic: discussion.topic,
+      slug: discussion.slug,
       createdAt: discussion.created_at,
     },
     counts: {
@@ -315,10 +343,11 @@ function buildSummary(discussion, questions, synthesis) {
   };
 }
 
-async function getDiscussionByTopic(topic) {
+async function getDiscussionBySlug(slug) {
+  const canonicalSlug = slugifyTopic(slug);
   const result = await pool.query(
-    'SELECT id, topic, created_at FROM discussions WHERE topic = $1 ORDER BY id DESC LIMIT 1',
-    [topic]
+    'SELECT id, topic, slug, created_at FROM discussions WHERE slug = $1 ORDER BY id DESC LIMIT 1',
+    [canonicalSlug]
   );
   return result.rows[0] || null;
 }
@@ -335,9 +364,10 @@ function emitPresence(topic) {
 
 // Read the lock state and whether a moderator has been claimed.
 async function getDiscussionState(topic) {
+  const slug = slugifyTopic(topic);
   const result = await pool.query(
-    'SELECT locked, admin_token IS NOT NULL AS has_moderator FROM discussions WHERE topic = $1',
-    [topic]
+    'SELECT locked, admin_token IS NOT NULL AS has_moderator FROM discussions WHERE slug = $1',
+    [slug]
   );
   if (result.rows.length === 0) return { locked: false, hasModerator: false };
   return { locked: result.rows[0].locked === true, hasModerator: result.rows[0].has_moderator === true };
@@ -352,22 +382,24 @@ io.on('connection', (socket) => {
   console.log('New client connected');
 
   socket.on('joinDiscussion', async (topic) => {
+    const discussionSlug = slugifyTopic(topic);
     // If this socket was viewing another discussion, leave it so presence
     // counts stay accurate as the user navigates within the SPA.
     const previousTopic = socket.data.topic;
-    if (previousTopic && previousTopic !== topic) {
+    if (previousTopic && previousTopic !== discussionSlug) {
       socket.leave(previousTopic);
       emitPresence(previousTopic);
     }
 
-    socket.join(topic);
-    socket.data.topic = topic;
-    emitPresence(topic);
+    socket.join(discussionSlug);
+    socket.data.topic = discussionSlug;
+    emitPresence(discussionSlug);
 
     try {
-      const questions = await getQuestions(topic);
+      socket.emit('discussion', await getDiscussionBySlug(discussionSlug));
+      const questions = await getQuestions(discussionSlug);
       socket.emit('questions', questions);
-      socket.emit('discussionState', await getDiscussionState(topic));
+      socket.emit('discussionState', await getDiscussionState(discussionSlug));
     } catch (error) {
       console.error('Error getting questions:', error);
       socket.emit('error', { message: 'Failed to get questions' });
@@ -387,12 +419,13 @@ io.on('connection', (socket) => {
   });
 
   socket.on('addQuestion', async (topic, question, force) => {
+    const discussionSlug = slugifyTopic(topic);
     console.log('Received addQuestion event');
-    console.log('topic:', topic);
+    console.log('topic:', discussionSlug);
     console.log('question:', question);
 
     try {
-      if (await isDiscussionLocked(topic)) {
+      if (await isDiscussionLocked(discussionSlug)) {
         socket.emit('error', { message: 'This discussion is locked.' });
         return;
       }
@@ -400,18 +433,19 @@ io.on('connection', (socket) => {
       // Surface a near-duplicate so the submitter can vote on the existing
       // statement instead — unless they explicitly chose to post anyway.
       if (!force) {
-        const similar = await findSimilarQuestion(topic, question.text);
+        const similar = await findSimilarQuestion(discussionSlug, question.text);
         if (similar) {
           socket.emit('similarQuestion', { candidate: similar, question });
           return;
         }
       }
 
-      await addQuestion(topic, question);
+      await addQuestion(discussionSlug, question);
       console.log('Question added successfully');
-      const updatedQuestions = await getQuestions(topic);
+      const updatedQuestions = await getQuestions(discussionSlug);
       console.log('Retrieved updated questions:', updatedQuestions);
-      io.to(topic).emit('questions', updatedQuestions);
+      io.to(discussionSlug).emit('discussion', await getDiscussionBySlug(discussionSlug));
+      io.to(discussionSlug).emit('questions', updatedQuestions);
     } catch (error) {
       console.error('Error adding question:', error);
       socket.emit('error', { message: 'Failed to add question' });
@@ -419,11 +453,12 @@ io.on('connection', (socket) => {
   });
 
   socket.on('vote', async (topic, questionId, vote, userId, pseudonym) => {
+    const discussionSlug = slugifyTopic(topic);
     try {
       // Verify the question actually belongs to this topic AND that the topic is
       // not locked. Without this, a client could bypass a locked discussion by
       // sending the locked question's id under some other (unlocked) topic.
-      const target = await getQuestionForTopic(topic, questionId);
+      const target = await getQuestionForTopic(discussionSlug, questionId);
       if (!target) {
         socket.emit('error', { message: 'Invalid question for this discussion.' });
         return;
@@ -433,8 +468,8 @@ io.on('connection', (socket) => {
         return;
       }
       await addVote(questionId, vote, userId, pseudonym);
-      const questions = await getQuestions(topic);
-      io.to(topic).emit('questions', questions);
+      const questions = await getQuestions(discussionSlug);
+      io.to(discussionSlug).emit('questions', questions);
     } catch (error) {
       console.error('Error handling vote:', error);
       socket.emit('error', { message: 'Failed to handle vote' });
@@ -443,11 +478,13 @@ io.on('connection', (socket) => {
 
   // First-come moderator claim. Replies via ack callback with the admin token.
   socket.on('claimModerator', async (topic, cb) => {
+    const discussionSlug = slugifyTopic(topic);
     try {
-      const token = await claimModerator(topic);
+      const token = await claimModerator(discussionSlug);
       if (token) {
         if (typeof cb === 'function') cb({ success: true, token });
-        await emitDiscussionState(topic);
+        io.to(discussionSlug).emit('discussion', await getDiscussionBySlug(discussionSlug));
+        await emitDiscussionState(discussionSlug);
       } else if (typeof cb === 'function') {
         cb({ success: false, error: 'already_claimed' });
       }
@@ -458,8 +495,9 @@ io.on('connection', (socket) => {
   });
 
   socket.on('deleteQuestion', async (topic, questionId, token) => {
+    const discussionSlug = slugifyTopic(topic);
     try {
-      const discussionId = await verifyAdmin(topic, token);
+      const discussionId = await verifyAdmin(discussionSlug, token);
       if (!discussionId) {
         socket.emit('error', { message: 'Not authorized to moderate this discussion.' });
         return;
@@ -475,7 +513,7 @@ io.on('connection', (socket) => {
         [questionId, discussionId]
       );
       await pool.query('DELETE FROM questions WHERE id = $1 AND discussion_id = $2', [questionId, discussionId]);
-      io.to(topic).emit('questions', await getQuestions(topic));
+      io.to(discussionSlug).emit('questions', await getQuestions(discussionSlug));
     } catch (error) {
       console.error('Error deleting question:', error);
       socket.emit('error', { message: 'Failed to delete question' });
@@ -483,14 +521,15 @@ io.on('connection', (socket) => {
   });
 
   socket.on('setLocked', async (topic, locked, token) => {
+    const discussionSlug = slugifyTopic(topic);
     try {
-      const discussionId = await verifyAdmin(topic, token);
+      const discussionId = await verifyAdmin(discussionSlug, token);
       if (!discussionId) {
         socket.emit('error', { message: 'Not authorized to moderate this discussion.' });
         return;
       }
       await pool.query('UPDATE discussions SET locked = $1 WHERE id = $2', [!!locked, discussionId]);
-      await emitDiscussionState(topic);
+      await emitDiscussionState(discussionSlug);
     } catch (error) {
       console.error('Error setting lock state:', error);
       socket.emit('error', { message: 'Failed to update discussion' });
@@ -498,14 +537,15 @@ io.on('connection', (socket) => {
   });
 
   socket.on('setPinned', async (topic, questionId, pinned, token) => {
+    const discussionSlug = slugifyTopic(topic);
     try {
-      const discussionId = await verifyAdmin(topic, token);
+      const discussionId = await verifyAdmin(discussionSlug, token);
       if (!discussionId) {
         socket.emit('error', { message: 'Not authorized to moderate this discussion.' });
         return;
       }
       await pool.query('UPDATE questions SET pinned = $1 WHERE id = $2 AND discussion_id = $3', [!!pinned, questionId, discussionId]);
-      io.to(topic).emit('questions', await getQuestions(topic));
+      io.to(discussionSlug).emit('questions', await getQuestions(discussionSlug));
     } catch (error) {
       console.error('Error setting pin state:', error);
       socket.emit('error', { message: 'Failed to update question' });
@@ -513,10 +553,11 @@ io.on('connection', (socket) => {
   });
 
   socket.on('toggleResponseVote', async (topic, responseId, userId) => {
+    const discussionSlug = slugifyTopic(topic);
     try {
-      await toggleResponseVote(topic, responseId, userId);
-      const questions = await getQuestions(topic);
-      io.to(topic).emit('questions', questions);
+      await toggleResponseVote(discussionSlug, responseId, userId);
+      const questions = await getQuestions(discussionSlug);
+      io.to(discussionSlug).emit('questions', questions);
     } catch (error) {
       console.error('Error toggling response vote:', error);
       socket.emit('error', { message: 'Failed to upvote response' });
@@ -524,10 +565,11 @@ io.on('connection', (socket) => {
   });
 
   socket.on('deleteVote', async (topic, voteId, userId) => {
+    const discussionSlug = slugifyTopic(topic);
     try {
       await deleteVote(voteId, userId);
-      const questions = await getQuestions(topic);
-      io.to(topic).emit('questions', questions);
+      const questions = await getQuestions(discussionSlug);
+      io.to(discussionSlug).emit('questions', questions);
     } catch (error) {
       console.error('Error deleting vote:', error);
       socket.emit('error', { message: 'Failed to delete vote' });
@@ -551,8 +593,8 @@ app.use((req, res, next) => {
 app.post('/api/discussions', async (req, res) => {
   const { topic } = req.body;
   try {
-    const id = await getOrCreateDiscussion(pool, topic);
-    res.json({ success: true, id });
+    const discussion = await getOrCreateDiscussion(pool, topic);
+    res.json({ success: true, ...discussion });
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'Server error' });
@@ -579,17 +621,32 @@ app.get('/api/discussions/:id', async (req, res) => {
 
 // Database functions
 async function getOrCreateDiscussion(db, topic) {
+  const displayTopic = formatTopicTitle(topic);
+  const slug = slugifyTopic(displayTopic);
   const result = await db.query(
-    `INSERT INTO discussions (topic)
-     VALUES ($1)
-     ON CONFLICT (topic) DO UPDATE SET topic = EXCLUDED.topic
-     RETURNING id`,
-    [topic]
+    `INSERT INTO discussions (topic, slug)
+     VALUES ($1, $2)
+     ON CONFLICT (slug) DO UPDATE SET slug = EXCLUDED.slug
+     RETURNING id, topic, slug`,
+    [displayTopic, slug]
   );
-  return result.rows[0].id;
+  return result.rows[0];
+}
+
+async function getOrCreateDiscussionForSlug(db, slug) {
+  const canonicalSlug = slugifyTopic(slug);
+  const result = await db.query(
+    `INSERT INTO discussions (topic, slug)
+     VALUES ($1, $2)
+     ON CONFLICT (slug) DO UPDATE SET slug = EXCLUDED.slug
+     RETURNING id, topic, slug`,
+    [titleFromSlug(canonicalSlug), canonicalSlug]
+  );
+  return result.rows[0];
 }
 
 async function getQuestions(topic) {
+  const slug = slugifyTopic(topic);
   const query = `
     SELECT 
       q.id, 
@@ -614,12 +671,12 @@ async function getQuestions(topic) {
     FROM questions q
     JOIN discussions d ON q.discussion_id = d.id
     LEFT JOIN votes v ON q.id = v.question_id
-    WHERE d.topic = $1
+    WHERE d.slug = $1
     GROUP BY q.id
     ORDER BY q.pinned DESC, q.id
   `;
 
-  const result = await pool.query(query, [topic]);
+  const result = await pool.query(query, [slug]);
   return result.rows.map(row => ({
     ...row,
     minValue: row.min_value,
@@ -637,7 +694,8 @@ async function addQuestion(topic, question) {
   try {
     await client.query('BEGIN');
 
-    const discussionId = await getOrCreateDiscussion(client, topic);
+    const discussion = await getOrCreateDiscussionForSlug(client, topic);
+    const discussionId = discussion.id;
 
     // Ensure options is a valid JSON array
     const optionsJson = JSON.stringify(Array.isArray(question.options) ? question.options : []);
@@ -747,6 +805,49 @@ async function migrateUniqueDiscussionTopics() {
   }
 }
 
+async function migrateDiscussionSlugs() {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query('ALTER TABLE discussions ADD COLUMN IF NOT EXISTS slug TEXT');
+
+    const result = await client.query('SELECT id, topic, slug FROM discussions ORDER BY id');
+    const usedSlugs = new Set();
+
+    for (const row of result.rows) {
+      const baseSlug = row.slug ? slugifyTopic(row.slug) : slugifyTopic(row.topic);
+      let slug = baseSlug;
+      let suffix = 2;
+      while (usedSlugs.has(slug)) {
+        const suffixText = `-${suffix}`;
+        slug = `${baseSlug.slice(0, 80 - suffixText.length)}${suffixText}`;
+        suffix += 1;
+      }
+
+      usedSlugs.add(slug);
+      if (row.slug !== slug) {
+        await client.query('UPDATE discussions SET slug = $1 WHERE id = $2', [slug, row.id]);
+      }
+    }
+
+    await client.query(`
+      UPDATE discussions
+      SET slug = id::text
+      WHERE slug IS NULL OR slug = ''
+    `);
+    await client.query('ALTER TABLE discussions ALTER COLUMN slug SET NOT NULL');
+    await client.query('CREATE UNIQUE INDEX IF NOT EXISTS discussions_slug_unique_idx ON discussions(slug)');
+    await client.query('COMMIT');
+    console.log('Discussion slug migration completed');
+  } catch (e) {
+    await client.query('ROLLBACK');
+    console.error('Error migrating discussion slugs:', e);
+    throw e;
+  } finally {
+    client.release();
+  }
+}
+
 // Table for upvotes on individual open-ended responses. One row per
 // (response, user); a response is identified by its votes.id. Idempotent.
 async function migrateResponseVotesTable() {
@@ -786,9 +887,10 @@ async function migrateModerationAndDedup() {
 // discussion id when valid, or null otherwise.
 async function verifyAdmin(topic, token) {
   if (!token) return null;
+  const slug = slugifyTopic(topic);
   const result = await pool.query(
-    'SELECT id FROM discussions WHERE topic = $1 AND admin_token = $2',
-    [topic, token]
+    'SELECT id FROM discussions WHERE slug = $1 AND admin_token = $2',
+    [slug, token]
   );
   return result.rows.length > 0 ? result.rows[0].id : null;
 }
@@ -798,20 +900,21 @@ async function verifyAdmin(topic, token) {
 // The advisory lock serializes moderator claims for the same topic; the upsert
 // also keeps the claim race-safe against non-moderator topic creation paths.
 async function claimModerator(topic) {
+  const slug = slugifyTopic(topic);
   const token = crypto.randomBytes(16).toString('hex');
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
-    await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [topic]);
+    await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [slug]);
 
     const claim = await client.query(
-      `INSERT INTO discussions (topic, admin_token)
-       VALUES ($1, $2)
-       ON CONFLICT (topic) DO UPDATE
+      `INSERT INTO discussions (topic, slug, admin_token)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (slug) DO UPDATE
        SET admin_token = COALESCE(discussions.admin_token, EXCLUDED.admin_token)
        WHERE discussions.admin_token IS NULL
        RETURNING admin_token`,
-      [topic, token]
+      [titleFromSlug(slug), slug, token]
     );
 
     await client.query('COMMIT');
@@ -826,7 +929,8 @@ async function claimModerator(topic) {
 
 // Whether voting is currently closed for a discussion.
 async function isDiscussionLocked(topic) {
-  const result = await pool.query('SELECT locked FROM discussions WHERE topic = $1', [topic]);
+  const slug = slugifyTopic(topic);
+  const result = await pool.query('SELECT locked FROM discussions WHERE slug = $1', [slug]);
   return result.rows.length > 0 ? result.rows[0].locked === true : false;
 }
 
@@ -835,12 +939,13 @@ async function isDiscussionLocked(topic) {
 // topic, so callers can reject mismatched/forged questionIds. The join on
 // topic means a question id from a different discussion never matches.
 async function getQuestionForTopic(topic, questionId) {
+  const slug = slugifyTopic(topic);
   const result = await pool.query(
     `SELECT q.id, d.locked
      FROM questions q
      JOIN discussions d ON q.discussion_id = d.id
-     WHERE d.topic = $1 AND q.id = $2`,
-    [topic, questionId]
+     WHERE d.slug = $1 AND q.id = $2`,
+    [slug, questionId]
   );
   if (result.rows.length === 0) return null;
   return { id: result.rows[0].id, locked: result.rows[0].locked === true };
@@ -851,15 +956,16 @@ async function getQuestionForTopic(topic, questionId) {
 const SIMILARITY_THRESHOLD = 0.5;
 async function findSimilarQuestion(topic, text) {
   if (!text) return null;
+  const slug = slugifyTopic(topic);
   try {
     const result = await pool.query(
       `SELECT q.text, similarity(q.text, $2) AS sim
        FROM questions q
        JOIN discussions d ON q.discussion_id = d.id
-       WHERE d.topic = $1 AND similarity(q.text, $2) > $3
+       WHERE d.slug = $1 AND similarity(q.text, $2) > $3
        ORDER BY sim DESC
        LIMIT 1`,
-      [topic, text, SIMILARITY_THRESHOLD]
+      [slug, text, SIMILARITY_THRESHOLD]
     );
     return result.rows.length > 0 ? result.rows[0].text : null;
   } catch (e) {
@@ -947,13 +1053,14 @@ async function toggleResponseVote(topic, responseId, userId) {
   // Without the topic join a client in one room could toggle a vote on a
   // response id that lives in another discussion. Also fetch the owner so we
   // can reject self-upvotes below.
+  const slug = slugifyTopic(topic);
   const ownerResult = await pool.query(
     `SELECT v.user_id
      FROM votes v
      JOIN questions q ON v.question_id = q.id
      JOIN discussions d ON q.discussion_id = d.id
-     WHERE v.id = $1 AND d.topic = $2`,
-    [responseId, topic]
+     WHERE v.id = $1 AND d.slug = $2`,
+    [responseId, slug]
   );
   if (ownerResult.rows.length === 0) {
     return;
@@ -990,7 +1097,7 @@ async function deleteVote(voteId, userId) {
 app.get('/api/discussions', async (req, res) => {
   try {
     const result = await pool.query(
-      'SELECT id, topic, created_at FROM discussions ORDER BY created_at DESC'
+      'SELECT id, topic, slug, created_at FROM discussions ORDER BY created_at DESC'
     );
     res.json(result.rows);
   } catch (err) {
@@ -1000,7 +1107,7 @@ app.get('/api/discussions', async (req, res) => {
 });
 
 async function getDiscussionSummary(topic, options = {}) {
-  const discussion = await getDiscussionByTopic(topic);
+  const discussion = await getDiscussionBySlug(topic);
   if (!discussion) {
     return null;
   }
@@ -1083,7 +1190,7 @@ app.get('/api/discussions/:topic/export.json', async (req, res) => {
 
 app.get('/api/discussions/:topic/export.csv', async (req, res) => {
   try {
-    const discussion = await getDiscussionByTopic(req.params.topic);
+    const discussion = await getDiscussionBySlug(req.params.topic);
     if (!discussion) {
       return res.status(404).json({ error: 'Discussion not found' });
     }
@@ -1158,8 +1265,8 @@ app.post('/api/duplicate-discussion', async (req, res) => {
 
     // Get the original discussion
     const originalDiscussionResult = await client.query(
-      'SELECT id FROM discussions WHERE topic = $1',
-      [originalTopic]
+      'SELECT id FROM discussions WHERE slug = $1',
+      [slugifyTopic(originalTopic)]
     );
 
     if (originalDiscussionResult.rows.length === 0) {
@@ -1171,12 +1278,13 @@ app.post('/api/duplicate-discussion', async (req, res) => {
     // Create new discussion. Duplicating into an existing topic would merge
     // questions into that discussion, so treat the unique conflict as a user
     // error instead.
+    const newSlug = slugifyTopic(newTopic);
     const newDiscussionResult = await client.query(
-      `INSERT INTO discussions (topic)
-       VALUES ($1)
-       ON CONFLICT (topic) DO NOTHING
-       RETURNING id`,
-      [newTopic]
+      `INSERT INTO discussions (topic, slug)
+       VALUES ($1, $2)
+       ON CONFLICT (slug) DO NOTHING
+       RETURNING id, topic, slug`,
+      [formatTopicTitle(newTopic), newSlug]
     );
 
     if (newDiscussionResult.rows.length === 0) {
@@ -1196,7 +1304,7 @@ app.post('/api/duplicate-discussion', async (req, res) => {
 
     await client.query('COMMIT');
 
-    res.json({ success: true, newTopic });
+    res.json({ success: true, newTopic: newDiscussionResult.rows[0].topic, newSlug: newDiscussionResult.rows[0].slug });
   } catch (error) {
     await client.query('ROLLBACK');
     console.error('Error duplicating discussion:', error);
@@ -1231,6 +1339,7 @@ const PORT = process.env.PORT || 3001;
 initSchema()
   .then(() => migrateModerationAndDedup())
   .then(() => migrateUniqueDiscussionTopics())
+  .then(() => migrateDiscussionSlugs())
   .then(() => Promise.all([migrateAddPseudonymColumn(), migrateResponseVotesTable()]))
   .then(() => {
     server.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -82,10 +82,24 @@ test('HTTP API creates and fetches discussions', async () => {
   assert.equal(createResponse.status, 200);
   assert.equal(createResponse.body.success, true);
   assert.equal(createResponse.body.id, 1);
+  assert.match(createResponse.body.slug, /^http-/);
 
   const fetchResponse = await jsonRequest('GET', `/api/discussions/${createResponse.body.id}`);
   assert.equal(fetchResponse.status, 200);
   assert.equal(fetchResponse.body.topic, topic);
+});
+
+test('HTTP API creates distinct discussions for colliding slugs', async () => {
+  const firstResponse = await jsonRequest('POST', '/api/discussions', { topic: 'C++' });
+  const secondResponse = await jsonRequest('POST', '/api/discussions', { topic: 'C#' });
+
+  assert.equal(firstResponse.status, 200);
+  assert.equal(secondResponse.status, 200);
+  assert.equal(firstResponse.body.topic, 'C++');
+  assert.equal(secondResponse.body.topic, 'C#');
+  assert.equal(firstResponse.body.slug, 'c');
+  assert.equal(secondResponse.body.slug, 'c-2');
+  assert.notEqual(firstResponse.body.id, secondResponse.body.id);
 });
 
 test('Socket.IO adds questions and broadcasts votes with pseudonyms', async () => {

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -14,31 +14,17 @@ const databaseUrl = process.env.DATABASE_URL || 'postgresql://convora:convora@12
 let serverProcess;
 let serverOutput = '';
 let baseUrl;
+let serverPort;
 let pool;
 
 test.before(async () => {
   assertSafeTestDatabase(databaseUrl);
 
-  const port = await getAvailablePort();
-  baseUrl = `http://127.0.0.1:${port}`;
+  serverPort = await getAvailablePort();
+  baseUrl = `http://127.0.0.1:${serverPort}`;
   pool = new Pool({ connectionString: databaseUrl });
 
-  serverProcess = spawn(process.execPath, ['server.js'], {
-    cwd: rootDir,
-    env: {
-      ...process.env,
-      NODE_ENV: 'test',
-      PORT: String(port),
-      DATABASE_URL: databaseUrl,
-      CLIENT_URL: baseUrl,
-    },
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
-
-  serverProcess.stdout.on('data', collectServerOutput);
-  serverProcess.stderr.on('data', collectServerOutput);
-
-  await waitForServer(baseUrl, serverProcess);
+  await startServer();
 });
 
 test.beforeEach(async () => {
@@ -50,10 +36,7 @@ test.after(async () => {
     await pool.end();
   }
 
-  if (serverProcess && serverProcess.exitCode === null) {
-    serverProcess.kill('SIGTERM');
-    await waitForExit(serverProcess);
-  }
+  await stopServer();
 });
 
 test('server startup creates schema and applies the pseudonym migration', async () => {
@@ -119,6 +102,30 @@ test('HTTP API resolves legacy title routes before falling back to canonical slu
   const resolveSlug = await jsonRequest('GET', '/api/discussions/resolve/c');
   assert.equal(resolveSlug.status, 200);
   assert.equal(resolveSlug.body.topic, 'C++');
+  assert.equal(resolveSlug.body.slug, 'c');
+});
+
+test('slug migration preserves literal slug-shaped legacy titles', async () => {
+  await stopServer();
+  await pool.query('TRUNCATE TABLE votes, questions, discussions RESTART IDENTITY CASCADE');
+  await pool.query(`
+    INSERT INTO discussions (topic, slug)
+    VALUES
+      ('C++', 'c'),
+      ('c', 'c-2')
+  `);
+
+  await startServer();
+
+  const migrated = await pool.query('SELECT topic, slug FROM discussions ORDER BY topic');
+  assert.deepEqual(migrated.rows, [
+    { topic: 'C++', slug: 'c-2' },
+    { topic: 'c', slug: 'c' },
+  ]);
+
+  const resolveSlug = await jsonRequest('GET', '/api/discussions/resolve/c');
+  assert.equal(resolveSlug.status, 200);
+  assert.equal(resolveSlug.body.topic, 'c');
   assert.equal(resolveSlug.body.slug, 'c');
 });
 
@@ -674,6 +681,33 @@ function connectSocket() {
     5000,
     'Timed out connecting Socket.IO client'
   );
+}
+
+async function startServer() {
+  serverOutput = '';
+  serverProcess = spawn(process.execPath, ['server.js'], {
+    cwd: rootDir,
+    env: {
+      ...process.env,
+      NODE_ENV: 'test',
+      PORT: String(serverPort),
+      DATABASE_URL: databaseUrl,
+      CLIENT_URL: baseUrl,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  serverProcess.stdout.on('data', collectServerOutput);
+  serverProcess.stderr.on('data', collectServerOutput);
+
+  await waitForServer(baseUrl, serverProcess);
+}
+
+async function stopServer() {
+  if (serverProcess && serverProcess.exitCode === null) {
+    serverProcess.kill('SIGTERM');
+    await waitForExit(serverProcess);
+  }
 }
 
 function waitForQuestions(socket, predicate, description) {


### PR DESCRIPTION
Adds canonical discussion slugs so display titles like "AI Safety" no longer diverge from route identifiers like `ai-safety`. The server now stores and migrates unique `discussions.slug` values, generates suffixed slugs for colliding new titles like `C++` and `C#`, and uses slugs for lookups, sockets, summaries, exports, moderation, and duplication while preserving `topic` as the display title. The client now navigates, shares, exports, and stores moderator tokens by slug, canonicalizes old title-style URLs without dropping query strings, and migrates existing local moderator tokens from pre-slug storage keys. This branch was merged with current `main` to resolve conflicts while preserving the facilitator report, Vite env, dependency, integration-test, and moderator join-QR changes already on `main`. Validation used: `npm run build`, `npx eslint .`, `node --check server.js`, and `npm test`.