### PR TITLE
Make share QR code scale to viewport for large rooms

### DIFF
--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -1001,13 +1001,19 @@ const DiscussionPage = () => {
                     className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full flex items-center justify-center"
                     onClick={() => setShowShareModal(false)}
                 >
-                    <div className="bg-white p-6 rounded-lg shadow-xl text-center" onClick={(e) => e.stopPropagation()}>
-                        <h2 className="text-xl font-bold mb-4">Share this discussion</h2>
+                    <div className="bg-white p-6 rounded-lg shadow-xl text-center max-w-[95vw] max-h-[95vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+                        <h2 className="text-2xl font-bold mb-4">Share this discussion</h2>
                         <div className="flex justify-center mb-4">
-                            <QRCodeSVG value={shareUrl} size={180} includeMargin />
+                            <QRCodeSVG
+                                value={shareUrl}
+                                size={1024}
+                                includeMargin
+                                className="w-auto h-auto max-w-full"
+                                style={{ width: 'min(80vw, 70vh)', height: 'min(80vw, 70vh)' }}
+                            />
                         </div>
-                        <p className="text-sm text-gray-500 mb-2">Scan to join, or copy the link:</p>
-                        <div className="flex items-center gap-2 mb-4">
+                        <p className="text-base text-gray-500 mb-2">Scan to join, or copy the link:</p>
+                        <div className="flex items-center gap-2 mb-4 max-w-2xl mx-auto w-full">
                             <input
                                 type="text"
                                 readOnly


### PR DESCRIPTION
The share popup rendered the QR code at a fixed 180px, which is too small to scan from the back of a large room. It now scales responsively to `min(80vw, 70vh)` (rendered at 1024px so it stays crisp) with the modal capped at 95vw/95vh and scrollable, so the QR fills a projected screen while still fitting on phones. Also bumped the heading/helper text and constrained the copy-link row so it doesn't stretch awkwardly beside the larger QR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)