### PR TITLE
Allow moderators to edit questions before the first response

### DIFF
--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -114,6 +114,8 @@ const DiscussionPage = () => {
     const [discussionState, setDiscussionState] = useState({ locked: false, hasModerator: false });
     const [similarPrompt, setSimilarPrompt] = useState(null);
     const [adminLinkCopied, setAdminLinkCopied] = useState(false);
+    // Id of the question a moderator is currently editing inline (null when none).
+    const [editingQuestionId, setEditingQuestionId] = useState(null);
     // Experimental "opinion groups" view, hidden behind a ?clusters=1 flag so it
     // can be evaluated on a real discussion without exposing it to everyone. Once
     // enabled it's remembered per browser so the link survives navigation.
@@ -381,6 +383,16 @@ const DiscussionPage = () => {
 
     const handleTogglePin = (questionId, pinned) => {
         socket.emit('setPinned', discussionSlug, questionId, !pinned, adminToken);
+    };
+
+    // Save a moderator's edit to a question. The server only accepts it while the
+    // question has no responses; on success it broadcasts fresh questions and we
+    // close the inline editor, otherwise the editor stays open to show the error.
+    const handleEditQuestion = (questionId, updates, onResult) => {
+        socket.emit('editQuestion', discussionSlug, questionId, updates, adminToken, (resp) => {
+            if (resp && resp.updated) setEditingQuestionId(null);
+            if (typeof onResult === 'function') onResult(resp);
+        });
     };
 
     const handleCopyAdminLink = async () => {
@@ -1243,8 +1255,21 @@ const DiscussionPage = () => {
             </div>
 
             {/* Questions list */}
-            {orderedQuestions.map((question) => (
+            {orderedQuestions.map((question) => {
+                // A question can only be edited before anyone has responded — once
+                // it has votes, its wording is locked in (matches the server guard).
+                const hasResponses = (question.votes?.length || 0) > 0;
+                const isEditing = editingQuestionId === question.id;
+                return (
                 <div key={question.id} className="bg-white shadow-lg rounded-lg p-6 mb-6">
+                    {isEditing ? (
+                        <QuestionEditor
+                            question={question}
+                            onSave={handleEditQuestion}
+                            onCancel={() => setEditingQuestionId(null)}
+                        />
+                    ) : (
+                    <>
                     <div className="flex justify-between items-start mb-4">
                         <h2 className="text-xl font-semibold">
                             {question.pinned && <span className="mr-1" title="Pinned">📌</span>}
@@ -1252,6 +1277,14 @@ const DiscussionPage = () => {
                         </h2>
                         {isAdmin && (
                             <div className="flex gap-2 ml-4 shrink-0">
+                                {!hasResponses && (
+                                    <button
+                                        onClick={() => setEditingQuestionId(question.id)}
+                                        className="text-xs px-2 py-1 rounded border border-gray-300 text-gray-600 hover:bg-gray-100"
+                                    >
+                                        Edit
+                                    </button>
+                                )}
                                 <button
                                     onClick={() => handleTogglePin(question.id, question.pinned)}
                                     className="text-xs px-2 py-1 rounded border border-gray-300 text-gray-600 hover:bg-gray-100"
@@ -1269,11 +1302,130 @@ const DiscussionPage = () => {
                     </div>
                     <p className="mb-4 text-sm text-gray-500">Type: {question.type}</p>
                     {renderVotingMechanism(question)}
+                    </>
+                    )}
                 </div>
-            ))}
+                );
+            })}
         </div>
     );
 };
+
+// Inline moderator editor for a question's wording/type, mirroring the fields of
+// the "add question" form. Only mounted for questions with no responses yet; the
+// server enforces that same rule, so a stale view can't slip an edit through.
+const QuestionEditor = ({ question, onSave, onCancel }) => {
+    const [text, setText] = useState(question.text);
+    const [type, setType] = useState(question.type);
+    const [minValue, setMinValue] = useState(question.minValue ?? 0);
+    const [maxValue, setMaxValue] = useState(question.maxValue ?? 100);
+    const [error, setError] = useState(null);
+    const [saving, setSaving] = useState(false);
+
+    const handleSave = () => {
+        const trimmed = text.trim();
+        if (trimmed === '') {
+            setError('Question text cannot be empty.');
+            return;
+        }
+        const updates = { text: trimmed, type };
+        if (type === QuestionTypes.NUMERICAL) {
+            const min = parseInt(minValue, 10);
+            const max = parseInt(maxValue, 10);
+            if (!Number.isInteger(min) || !Number.isInteger(max) || min >= max) {
+                setError('Minimum value must be less than maximum value.');
+                return;
+            }
+            updates.minValue = min;
+            updates.maxValue = max;
+        }
+        setError(null);
+        setSaving(true);
+        onSave(question.id, updates, (resp) => {
+            setSaving(false);
+            if (!resp || !resp.updated) {
+                setError(
+                    resp && resp.reason === 'has_responses'
+                        ? 'This question already has responses and can no longer be edited.'
+                        : 'Failed to save changes. Please try again.'
+                );
+            }
+            // On success the parent unmounts this editor; nothing more to do here.
+        });
+    };
+
+    return (
+        <div>
+            <input
+                type="text"
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+                placeholder="Enter a new question or statement"
+                className="w-full p-3 border border-gray-300 rounded-md mb-4 focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+            <div className="mb-4">
+                <label className="block mb-2">Question Type:</label>
+                <select
+                    value={type}
+                    onChange={(e) => setType(e.target.value)}
+                    className="w-full p-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
+                >
+                    {Object.values(QuestionTypes).map(t => (
+                        <option key={t} value={t}>{t}</option>
+                    ))}
+                </select>
+                {QuestionTypeDescriptions[type] && (
+                    <p className="mt-2 text-sm text-gray-500">{QuestionTypeDescriptions[type]}</p>
+                )}
+            </div>
+            {type === QuestionTypes.NUMERICAL && (
+                <div className="mb-4 flex space-x-4">
+                    <div className="flex-1">
+                        <label className="block mb-2">Min Value:</label>
+                        <input
+                            type="number"
+                            value={minValue}
+                            onChange={(e) => setMinValue(e.target.value)}
+                            className="w-full p-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
+                        />
+                    </div>
+                    <div className="flex-1">
+                        <label className="block mb-2">Max Value:</label>
+                        <input
+                            type="number"
+                            value={maxValue}
+                            onChange={(e) => setMaxValue(e.target.value)}
+                            className="w-full p-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
+                        />
+                    </div>
+                </div>
+            )}
+            {error && <div className="text-red-500 mb-3 text-sm">{error}</div>}
+            <div className="flex gap-2">
+                <button
+                    onClick={handleSave}
+                    disabled={saving}
+                    className="px-4 py-2 bg-primary text-white rounded hover:bg-opacity-90 transition duration-300 disabled:opacity-50"
+                >
+                    {saving ? 'Saving…' : 'Save'}
+                </button>
+                <button
+                    onClick={onCancel}
+                    disabled={saving}
+                    className="px-4 py-2 rounded border border-gray-300 text-gray-600 hover:bg-gray-100 transition duration-300 disabled:opacity-50"
+                >
+                    Cancel
+                </button>
+            </div>
+        </div>
+    );
+};
+QuestionEditor.propTypes = {
+    question: PropTypes.object.isRequired,
+    onSave: PropTypes.func.isRequired,
+    onCancel: PropTypes.func.isRequired,
+};
+
 const OpenEndedQuestion = ({ question, userVote, handleVote, ownedVoteIds, upvotedVoteIds, handleResponseVote, locked }) => {
     const [response, setResponse] = useState(userVote ? userVote.value : '');
 

--- a/server.js
+++ b/server.js
@@ -978,6 +978,80 @@ io.on('connection', (socket) => {
     }
   });
 
+  // Moderator-only: edit a question's wording/type, allowed ONLY while it has no
+  // responses yet. Once anyone has answered, the wording is a contract their
+  // responses were made against, so editing is refused (delete + re-ask instead).
+  socket.on('editQuestion', async (topic, questionId, updates, token, ack) => {
+    const discussionSlug = slugifyTopic(topic);
+    const reply = (result) => { if (typeof ack === 'function') ack(result); };
+    try {
+      const discussionId = await verifyAdmin(discussionSlug, token);
+      if (!discussionId) {
+        socket.emit('error', { message: 'Not authorized to moderate this discussion.' });
+        reply({ updated: false, reason: 'not_authorized' });
+        return;
+      }
+
+      // Scope existence through discussion_id so a moderator of one discussion
+      // can't probe or edit another's questions by passing a foreign id.
+      const existing = await pool.query(
+        'SELECT id FROM questions WHERE id = $1 AND discussion_id = $2',
+        [questionId, discussionId]
+      );
+      if (existing.rows.length === 0) {
+        reply({ updated: false, reason: 'not_found' });
+        return;
+      }
+
+      const responses = await pool.query('SELECT 1 FROM votes WHERE question_id = $1 LIMIT 1', [questionId]);
+      if (responses.rows.length > 0) {
+        socket.emit('error', { message: 'This question already has responses and can no longer be edited.' });
+        reply({ updated: false, reason: 'has_responses' });
+        return;
+      }
+
+      // Validate the same way creation does: non-empty text, a known type, and
+      // (for Numerical) a valid min < max range.
+      const text = String(updates && updates.text != null ? updates.text : '').trim();
+      const type = updates && updates.type;
+      if (!text || !VALID_QUESTION_TYPES.has(type)) {
+        reply({ updated: false, reason: 'invalid' });
+        return;
+      }
+      let minValue = null;
+      let maxValue = null;
+      if (type === 'Numerical') {
+        minValue = parseInt(updates.minValue, 10);
+        maxValue = parseInt(updates.maxValue, 10);
+        if (!Number.isInteger(minValue) || !Number.isInteger(maxValue) || minValue >= maxValue) {
+          reply({ updated: false, reason: 'invalid' });
+          return;
+        }
+      }
+
+      // The NOT EXISTS guard closes the race between the response check above and
+      // this write: if a vote landed in between, no row is updated and we report
+      // it as having responses rather than silently editing an answered question.
+      const result = await pool.query(
+        `UPDATE questions SET text = $1, type = $2, min_value = $3, max_value = $4
+         WHERE id = $5 AND discussion_id = $6
+           AND NOT EXISTS (SELECT 1 FROM votes WHERE question_id = $5)`,
+        [text, type, minValue, maxValue, questionId, discussionId]
+      );
+      if (result.rowCount === 0) {
+        socket.emit('error', { message: 'This question already has responses and can no longer be edited.' });
+        reply({ updated: false, reason: 'has_responses' });
+        return;
+      }
+      io.to(discussionSlug).emit('questions', await getQuestions(discussionSlug));
+      reply({ updated: true });
+    } catch (error) {
+      console.error('Error editing question:', error);
+      socket.emit('error', { message: 'Failed to edit question' });
+      reply({ updated: false, reason: 'error' });
+    }
+  });
+
   socket.on('toggleResponseVote', async (topic, responseId, userId) => {
     const discussionSlug = slugifyTopic(topic);
     try {
@@ -1345,6 +1419,10 @@ const EPISTEMIC_REACTIONS = new Set([
   'citation-needed',
   'key-insight',
 ]);
+
+// The question types a discussion supports. Mirrors QuestionTypes in
+// client/src/DiscussionPage.jsx — used to validate edits server-side.
+const VALID_QUESTION_TYPES = new Set(['Agreement', 'Numerical', 'Open Ended', 'Brainstorm']);
 
 // Enrich Brainstorm responses in place with aggregated interaction data:
 // quality up/down tallies, the agreement distribution, reaction counts, and

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -985,6 +985,92 @@ test('Duplicating a discussion preserves brainstorm interaction flags', async ()
   }
 });
 
+test('a moderator can edit a question before anyone responds', async () => {
+  const topic = uniqueTopic('edit-question');
+  const mod = await connectSocket();
+
+  try {
+    mod.emit('joinDiscussion', topic);
+    const token = await claimModerator(mod, topic);
+
+    const added = waitForQuestions(mod, (qs) => qs.some((q) => q.text === 'Typoo?'), 'question added');
+    mod.emit('addQuestion', topic, { text: 'Typoo?', type: 'Agreement', minValue: null, maxValue: null, options: [] });
+    const question = (await added).find((q) => q.text === 'Typoo?');
+
+    // Edit both the wording and the type (to Numerical, so min/max are applied).
+    const editedUpdate = waitForQuestions(mod, (qs) => qs[0] && qs[0].text === 'Pick a budget', 'edit broadcast');
+    const ack = await emitWithAck(mod, 'editQuestion', topic, question.id,
+      { text: 'Pick a budget', type: 'Numerical', minValue: 0, maxValue: 10 }, token);
+    assert.equal(ack.updated, true);
+
+    const edited = (await editedUpdate)[0];
+    assert.equal(edited.text, 'Pick a budget');
+    assert.equal(edited.type, 'Numerical');
+    assert.equal(edited.minValue, 0);
+    assert.equal(edited.maxValue, 10);
+  } finally {
+    mod.disconnect();
+  }
+});
+
+test('editing a question is refused once it has responses', async () => {
+  const topic = uniqueTopic('edit-locked');
+  const mod = await connectSocket();
+  const participant = await connectSocket();
+
+  try {
+    mod.emit('joinDiscussion', topic);
+    participant.emit('joinDiscussion', topic);
+    const token = await claimModerator(mod, topic);
+
+    const added = waitForQuestions(mod, (qs) => qs.some((q) => q.text === 'Keep cars?'), 'question added');
+    mod.emit('addQuestion', topic, { text: 'Keep cars?', type: 'Agreement', minValue: null, maxValue: null, options: [] });
+    const question = (await added).find((q) => q.text === 'Keep cars?');
+
+    const voted = waitForQuestions(mod, (qs) => qs[0] && qs[0].votes.length === 1, 'vote recorded');
+    participant.emit('vote', topic, question.id, 'Agree', 'user-voter', 'Voter');
+    await voted;
+
+    const ack = await emitWithAck(mod, 'editQuestion', topic, question.id,
+      { text: 'Restrict cars?', type: 'Agreement' }, token);
+    assert.equal(ack.updated, false);
+    assert.equal(ack.reason, 'has_responses');
+
+    // The original wording must be untouched — the response was made against it.
+    const row = await pool.query('SELECT text FROM questions WHERE id = $1', [question.id]);
+    assert.equal(row.rows[0].text, 'Keep cars?');
+  } finally {
+    mod.disconnect();
+    participant.disconnect();
+  }
+});
+
+test('a non-moderator cannot edit a question', async () => {
+  const topic = uniqueTopic('edit-authz');
+  const mod = await connectSocket();
+  const stranger = await connectSocket();
+
+  try {
+    mod.emit('joinDiscussion', topic);
+    await claimModerator(mod, topic);
+
+    const added = waitForQuestions(mod, (qs) => qs.some((q) => q.text === 'Original?'), 'question added');
+    mod.emit('addQuestion', topic, { text: 'Original?', type: 'Agreement', minValue: null, maxValue: null, options: [] });
+    const question = (await added).find((q) => q.text === 'Original?');
+
+    const ack = await emitWithAck(stranger, 'editQuestion', topic, question.id,
+      { text: 'Hijacked?', type: 'Agreement' }, 'bogus-token');
+    assert.equal(ack.updated, false);
+    assert.equal(ack.reason, 'not_authorized');
+
+    const row = await pool.query('SELECT text FROM questions WHERE id = $1', [question.id]);
+    assert.equal(row.rows[0].text, 'Original?');
+  } finally {
+    mod.disconnect();
+    stranger.disconnect();
+  }
+});
+
 function claimModerator(socket, topic) {
   return withTimeout(
     new Promise((resolve, reject) => {


### PR DESCRIPTION
Moderators can now edit a question's wording, type, and (for Numerical) min/max — but only while it has zero responses, since editing an answered question would silently invalidate votes made against the original wording. The new `editQuestion` socket handler is host-gated and refuses once responses exist, using an atomic `NOT EXISTS (SELECT 1 FROM votes…)` guard to close the check→write race, with matching validation to the create flow. On the client, an inline `QuestionEditor` (mirroring the add-question form) appears behind an Edit button that's shown only for unanswered questions. Three integration tests cover the happy path, refusal once a response exists, and rejection of non-moderators. `npm run build` is clean and all 28 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)