### PR TITLE
Add a Yes/No question type as a binary alternative to Agreement

### DIFF
--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -703,13 +703,21 @@ const DiscussionPage = () => {
         }
     };
 
+    // Only Agreement and Yes/No are opinion prompts; the agreement sorts ignore
+    // other types so an Open Ended / Brainstorm answer that happens to read
+    // "Yes", "No", "Agree", etc. can't mis-rank a non-opinion question.
+    const isOpinionQuestion = (question) =>
+        question?.type === QuestionTypes.AGREEMENT || question?.type === QuestionTypes.YES_NO;
+
     // Yes/No votes count toward the same agreement/disagreement sorts as the
     // five-point scale: Yes reads as agreement, No as disagreement.
     const getAgreementCount = (question) => {
+        if (!isOpinionQuestion(question)) return 0;
         return (question.votes || []).filter(v => v.value === VoteOptions.STRONGLY_AGREE || v.value === VoteOptions.AGREE || v.value === YesNoOptions.YES).length;
     };
 
     const getDisagreementCount = (question) => {
+        if (!isOpinionQuestion(question)) return 0;
         return (question.votes || []).filter(v => v.value === VoteOptions.STRONGLY_DISAGREE || v.value === VoteOptions.DISAGREE || v.value === YesNoOptions.NO).length;
     };
 

--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -20,6 +20,7 @@ console.log('Convora version:', VERSION);
 
 const QuestionTypes = {
     AGREEMENT: 'Agreement',
+    YES_NO: 'Yes/No',
     NUMERICAL: 'Numerical',
     OPEN_ENDED: 'Open Ended',
     BRAINSTORM: 'Brainstorm'
@@ -27,7 +28,8 @@ const QuestionTypes = {
 
 // Shown under the type picker so creators understand what each type does.
 const QuestionTypeDescriptions = {
-    [QuestionTypes.AGREEMENT]: 'Each participant picks one option from Strongly Agree to Strongly Disagree.',
+    [QuestionTypes.AGREEMENT]: 'Each participant picks one option on the five-point scale from Strongly Agree to Strongly Disagree.',
+    [QuestionTypes.YES_NO]: 'Each participant picks a simple Yes or No — a binary alternative to the five-point agreement scale.',
     [QuestionTypes.NUMERICAL]: 'Each participant submits a single number on a slider between your min and max.',
     [QuestionTypes.OPEN_ENDED]: 'Each participant gives one free-text response, which they can edit later. One answer per person.',
     [QuestionTypes.BRAINSTORM]: 'Each participant can add as many separate ideas as they want, and remove their own. Many answers per person.'
@@ -39,6 +41,13 @@ const VoteOptions = {
     UNSURE: 'Unsure',
     DISAGREE: 'Disagree',
     STRONGLY_DISAGREE: 'Strongly Disagree',
+};
+
+// The two choices for a Yes/No question. Listed Yes-first so the green/red
+// divergence bar reads left-to-right the same way the agreement bar does.
+const YesNoOptions = {
+    YES: 'Yes',
+    NO: 'No',
 };
 
 const SortOptions = {
@@ -694,12 +703,14 @@ const DiscussionPage = () => {
         }
     };
 
+    // Yes/No votes count toward the same agreement/disagreement sorts as the
+    // five-point scale: Yes reads as agreement, No as disagreement.
     const getAgreementCount = (question) => {
-        return (question.votes || []).filter(v => v.value === VoteOptions.STRONGLY_AGREE || v.value === VoteOptions.AGREE).length;
+        return (question.votes || []).filter(v => v.value === VoteOptions.STRONGLY_AGREE || v.value === VoteOptions.AGREE || v.value === YesNoOptions.YES).length;
     };
 
     const getDisagreementCount = (question) => {
-        return (question.votes || []).filter(v => v.value === VoteOptions.STRONGLY_DISAGREE || v.value === VoteOptions.DISAGREE).length;
+        return (question.votes || []).filter(v => v.value === VoteOptions.STRONGLY_DISAGREE || v.value === VoteOptions.DISAGREE || v.value === YesNoOptions.NO).length;
     };
 
     const getControversyScore = (question) => {
@@ -741,6 +752,32 @@ const DiscussionPage = () => {
                         {!locked && (
                             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                                 {Object.values(VoteOptions).map((option) => (
+                                    <div key={option} className="flex items-center justify-between bg-gray-100 p-3 rounded-md">
+                                        <span className="font-medium">
+                                            {option}: {question.votes ? question.votes.filter(v => v.value === option).length : 0}
+                                        </span>
+                                        <button
+                                            onClick={() => handleVote(question.id, option)}
+                                            className={`px-4 py-2 rounded-md transition duration-300 ${userVote && userVote.value === option
+                                                ? 'bg-primary text-white hover:bg-opacity-90'
+                                                : 'bg-secondary text-white hover:bg-opacity-90'
+                                                }`}
+                                        >
+                                            {userVote && userVote.value === option ? 'Undo Vote' : 'Vote'}
+                                        </button>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                );
+            case QuestionTypes.YES_NO:
+                return (
+                    <div>
+                        <YesNoResults question={question} />
+                        {!locked && (
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                {Object.values(YesNoOptions).map((option) => (
                                     <div key={option} className="flex items-center justify-between bg-gray-100 p-3 rounded-md">
                                         <span className="font-medium">
                                             {option}: {question.votes ? question.votes.filter(v => v.value === option).length : 0}
@@ -1492,6 +1529,74 @@ const AgreementResults = ({ question }) => {
 };
 
 AgreementResults.propTypes = {
+    question: PropTypes.shape({
+        votes: PropTypes.array,
+    }).isRequired,
+};
+
+// Stacked divergence bar + summary for a Yes/No question — the binary sibling of
+// AgreementResults. Yes is green, No is red, mirroring the agreement scale.
+const YesNoResults = ({ question }) => {
+    const votes = question.votes || [];
+    const total = votes.length;
+
+    if (total === 0) {
+        return <p className="text-sm text-gray-500 mb-4">No votes yet — be the first to weigh in.</p>;
+    }
+
+    const yesCount = votes.filter(v => v.value === YesNoOptions.YES).length;
+    const noCount = votes.filter(v => v.value === YesNoOptions.NO).length;
+    const yesPct = Math.round((yesCount / total) * 100);
+    const noPct = Math.round((noCount / total) * 100);
+
+    // Divisive when the room is split roughly evenly; consensus when one side
+    // clearly dominates. Mirrors the thresholds used for agreement questions.
+    let badge = null;
+    if (total >= 2) {
+        const split = Math.min(yesCount, noCount) / total; // 0..0.5
+        if (split >= 0.4) {
+            badge = <span className="px-2 py-0.5 text-xs font-semibold rounded-full bg-amber-100 text-amber-800">Divisive</span>;
+        } else if (split <= 0.15) {
+            badge = <span className="px-2 py-0.5 text-xs font-semibold rounded-full bg-emerald-100 text-emerald-800">Consensus</span>;
+        }
+    }
+
+    const segments = [
+        { key: YesNoOptions.NO, label: 'No', count: noCount, bar: 'bg-red-500', dot: 'bg-red-500' },
+        { key: YesNoOptions.YES, label: 'Yes', count: yesCount, bar: 'bg-green-500', dot: 'bg-green-500' },
+    ];
+
+    return (
+        <div className="mb-4">
+            <div className="flex items-center justify-between mb-2">
+                <span className="text-sm text-gray-600">
+                    {total} {total === 1 ? 'vote' : 'votes'} · {yesPct}% yes · {noPct}% no
+                </span>
+                {badge}
+            </div>
+            <div className="flex w-full h-4 rounded-full overflow-hidden bg-gray-200">
+                {segments.map(seg => seg.count > 0 && (
+                    <div
+                        key={seg.key}
+                        className={seg.bar}
+                        style={{ width: `${(seg.count / total) * 100}%` }}
+                        title={`${seg.label}: ${seg.count}`}
+                    />
+                ))}
+            </div>
+            <div className="flex flex-wrap gap-x-4 gap-y-1 mt-2">
+                {segments.map(seg => (
+                    <span key={seg.key} className="flex items-center text-xs text-gray-600">
+                        <span className={`inline-block w-2.5 h-2.5 rounded-full mr-1 ${seg.dot}`} />
+                        {seg.label}: {seg.count}
+                    </span>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+YesNoResults.propTypes = {
     question: PropTypes.shape({
         votes: PropTypes.array,
     }).isRequired,

--- a/client/src/SummaryPage.jsx
+++ b/client/src/SummaryPage.jsx
@@ -397,7 +397,7 @@ const RankedAgreementList = ({ title, items, metricLabel, metricKey }) => (
     <section className="bg-white shadow rounded-lg p-6">
         <h2 className="text-2xl font-bold mb-4 text-gray-800">{title}</h2>
         {items.length === 0 ? (
-            <p className="text-sm text-gray-500">No agreement responses yet.</p>
+            <p className="text-sm text-gray-500">No opinion responses yet.</p>
         ) : (
             <ol className="space-y-4">
                 {items.map(item => (
@@ -413,7 +413,11 @@ const RankedAgreementList = ({ title, items, metricLabel, metricKey }) => (
                                 {metricLabel}: {formatPercent(item[metricKey])}
                             </span>
                         </div>
-                        <AgreementBar optionCounts={item.optionCounts} total={item.responseCount} />
+                        {item.type === 'Yes/No' ? (
+                            <YesNoBar optionCounts={item.optionCounts} total={item.responseCount} />
+                        ) : (
+                            <AgreementBar optionCounts={item.optionCounts} total={item.responseCount} />
+                        )}
                     </li>
                 ))}
             </ol>
@@ -424,6 +428,7 @@ const RankedAgreementList = ({ title, items, metricLabel, metricKey }) => (
 const AgreementItemShape = PropTypes.shape({
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     text: PropTypes.string.isRequired,
+    type: PropTypes.string,
     responseCount: PropTypes.number.isRequired,
     leadingPosition: PropTypes.string,
     consensusScore: PropTypes.number,

--- a/client/src/SummaryPage.jsx
+++ b/client/src/SummaryPage.jsx
@@ -261,7 +261,7 @@ const FacilitatorDashboard = ({ dashboard }) => {
                     title="Most Divisive Statements"
                     emptyText="No divisive agreement statements yet."
                     items={dashboard.mostDivisiveStatements}
-                    renderMeta={item => `${item.agreeCount} agree / ${item.disagreeCount} disagree / ${item.unsureCount} unsure`}
+                    renderMeta={item => item.detail}
                     renderScore={item => `Split ${formatPercent(item.divisiveScore)}`}
                 />
                 <FacilitatorSignalList

--- a/client/src/SummaryPage.jsx
+++ b/client/src/SummaryPage.jsx
@@ -11,6 +11,9 @@ const AGREEMENT_OPTIONS = [
     'Strongly Agree',
 ];
 
+// No-first so the green/red bar reads the same direction as the agreement bar.
+const YES_NO_OPTIONS = ['No', 'Yes'];
+
 function formatPercent(value) {
     if (!Number.isFinite(value)) {
         return '0%';
@@ -480,6 +483,48 @@ AgreementBar.propTypes = {
     total: PropTypes.number.isRequired,
 };
 
+const YesNoBar = ({ optionCounts, total }) => {
+    if (!total) {
+        return null;
+    }
+
+    const colors = {
+        No: 'bg-red-500',
+        Yes: 'bg-green-500',
+    };
+
+    return (
+        <div className="mt-3">
+            <div className="flex w-full h-3 rounded-full overflow-hidden bg-gray-200">
+                {YES_NO_OPTIONS.map(option => {
+                    const count = optionCounts[option] || 0;
+                    if (count === 0) {
+                        return null;
+                    }
+                    return (
+                        <div
+                            key={option}
+                            className={colors[option]}
+                            style={{ width: `${(count / total) * 100}%` }}
+                            title={`${option}: ${count}`}
+                        />
+                    );
+                })}
+            </div>
+            <div className="flex flex-wrap gap-x-3 gap-y-1 mt-2 text-xs text-gray-500">
+                {YES_NO_OPTIONS.map(option => (
+                    <span key={option}>{option}: {optionCounts[option] || 0}</span>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+YesNoBar.propTypes = {
+    optionCounts: PropTypes.objectOf(PropTypes.number).isRequired,
+    total: PropTypes.number.isRequired,
+};
+
 const SynthesisPanel = ({ synthesis }) => (
     <section className="bg-white shadow rounded-lg p-6">
         <div className="flex items-center justify-between gap-4 mb-4">
@@ -588,6 +633,10 @@ const QuestionSummary = ({ question }) => (
 
         {question.type === 'Agreement' && (
             <AgreementBar optionCounts={question.optionCounts} total={question.responseCount} />
+        )}
+
+        {question.type === 'Yes/No' && (
+            <YesNoBar optionCounts={question.optionCounts} total={question.responseCount} />
         )}
 
         {question.type === 'Numerical' && (

--- a/server.js
+++ b/server.js
@@ -263,10 +263,14 @@ function buildFacilitatorDashboard(questionSummaries, participantStats) {
     .map(question => ({
       id: question.id,
       text: question.text,
+      type: question.type,
       responseCount: question.responseCount,
       agreeCount: question.agreeCount,
       disagreeCount: question.disagreeCount,
       unsureCount: question.unsureCount,
+      // Preformatted so renderers don't have to know the prompt type: Yes/No
+      // reads "yes / no", the five-point scale reads "agree / disagree / unsure".
+      detail: opinionTensionDetail(question),
       divisiveScore: roundMetric(question.divisiveScore),
       leadingPosition: question.leadingPosition,
     }))
@@ -701,7 +705,7 @@ function renderReportHtml(summary) {
     <section class="split">
       <div>
         <h2>Most Divisive Statements</h2>
-        ${renderList(dashboard.mostDivisiveStatements, 'No divisive agreement statements yet.', item => `<li><strong>${escapeHtml(formatReportPercent(item.divisiveScore))}</strong> split | ${escapeHtml(item.text)}<br><span class="muted">${item.agreeCount} agree / ${item.disagreeCount} disagree / ${item.unsureCount} unsure</span></li>`)}
+        ${renderList(dashboard.mostDivisiveStatements, 'No divisive agreement statements yet.', item => `<li><strong>${escapeHtml(formatReportPercent(item.divisiveScore))}</strong> split | ${escapeHtml(item.text)}<br><span class="muted">${escapeHtml(item.detail)}</span></li>`)}
       </div>
       <div>
         <h2>Unanswered Prompts</h2>

--- a/server.js
+++ b/server.js
@@ -67,6 +67,11 @@ const AGREEMENT_OPTIONS = [
   'Strongly Agree',
 ];
 
+// Yes/No questions are a binary opinion type: Yes reads as agreement, No as
+// disagreement, so they feed the same consensus/divisive analysis as the
+// five-point agreement scale.
+const YES_NO_OPTIONS = ['No', 'Yes'];
+
 function sanitizeFilename(value) {
   return String(value || 'discussion')
     .replace(/[^a-z0-9-_]+/gi, '-')
@@ -243,10 +248,17 @@ function buildFacilitatorDashboard(questionSummaries, participantStats) {
 
   const participantCount = participants.length;
   const totalResponses = participants.reduce((sum, participant) => sum + participant.responseCount, 0);
-  const agreementPrompts = questionSummaries.filter(question => question.type === 'Agreement');
+  // Agreement and Yes/No are both single-choice opinion prompts, so they share
+  // the divisiveness analysis. Yes/No phrasing uses "yes/no" rather than the
+  // five-point scale's "agree/disagree/unsure".
+  const opinionPrompts = questionSummaries.filter(question => question.type === 'Agreement' || question.type === 'Yes/No');
   const numericalPrompts = questionSummaries.filter(question => question.type === 'Numerical');
 
-  const mostDivisiveStatements = agreementPrompts
+  const opinionTensionDetail = (question) => question.type === 'Yes/No'
+    ? `${question.agreeCount} yes / ${question.disagreeCount} no`
+    : `${question.agreeCount} agree / ${question.disagreeCount} disagree / ${question.unsureCount} unsure`;
+
+  const mostDivisiveStatements = opinionPrompts
     .filter(question => question.decidedCount >= 2)
     .map(question => ({
       id: question.id,
@@ -261,14 +273,14 @@ function buildFacilitatorDashboard(questionSummaries, participantStats) {
     .sort((a, b) => b.divisiveScore - a.divisiveScore || b.responseCount - a.responseCount)
     .slice(0, 5);
 
-  const agreementTensions = agreementPrompts
+  const agreementTensions = opinionPrompts
     .filter(question => question.decidedCount >= 2 && question.divisiveScore >= 0.35)
     .map(question => ({
       id: question.id,
       type: 'Opinion split',
       text: question.text,
       severity: roundMetric(question.divisiveScore),
-      detail: `${question.agreeCount} agree / ${question.disagreeCount} disagree / ${question.unsureCount} unsure`,
+      detail: opinionTensionDetail(question),
     }));
 
   const numericalTensions = numericalPrompts
@@ -456,7 +468,7 @@ function buildSummary(discussion, questions, synthesis) {
         const participant = participantMap.get(participantKey);
         participant.responseCount += 1;
         participant.answeredQuestionIds.add(question.id);
-        if (question.type === 'Agreement') {
+        if (question.type === 'Agreement' || question.type === 'Yes/No') {
           participant.agreementResponseCount += 1;
         } else if (question.type === 'Numerical') {
           participant.numericalResponseCount += 1;
@@ -498,6 +510,31 @@ function buildSummary(discussion, questions, synthesis) {
         divisiveScore,
         label: decidedCount < 2 ? 'Not enough votes' : divisiveScore >= 0.4 ? 'Divisive' : consensusScore >= 0.85 ? 'Consensus' : 'Mixed',
         leadingPosition: agreeCount === disagreeCount ? 'Split' : agreeCount > disagreeCount ? 'Agree' : 'Disagree',
+      };
+    }
+
+    if (question.type === 'Yes/No') {
+      const optionCounts = YES_NO_OPTIONS.reduce((acc, option) => {
+        acc[option] = votes.filter(vote => vote.value === option).length;
+        return acc;
+      }, {});
+      const agreeCount = optionCounts.Yes;
+      const disagreeCount = optionCounts.No;
+      const decidedCount = agreeCount + disagreeCount;
+      const consensusScore = decidedCount > 0 ? Math.max(agreeCount, disagreeCount) / decidedCount : 0;
+      const divisiveScore = decidedCount > 0 ? Math.min(agreeCount, disagreeCount) / decidedCount : 0;
+
+      return {
+        ...base,
+        optionCounts,
+        agreeCount,
+        disagreeCount,
+        unsureCount: 0,
+        decidedCount,
+        consensusScore,
+        divisiveScore,
+        label: decidedCount < 2 ? 'Not enough votes' : divisiveScore >= 0.4 ? 'Divisive' : consensusScore >= 0.85 ? 'Consensus' : 'Mixed',
+        leadingPosition: agreeCount === disagreeCount ? 'Split' : agreeCount > disagreeCount ? 'Yes' : 'No',
       };
     }
 
@@ -582,9 +619,11 @@ function renderReportHtml(summary) {
     const label = question.label ? `<span class="pill">${escapeHtml(question.label)}</span>` : '';
     const metric = question.type === 'Agreement'
       ? `${question.agreeCount || 0} agree / ${question.disagreeCount || 0} disagree / ${question.unsureCount || 0} unsure`
-      : question.type === 'Numerical'
-        ? `Avg ${question.average === null ? '-' : roundMetric(question.average, 1)} | Low ${question.minResponse ?? '-'} | High ${question.maxResponse ?? '-'}`
-        : `${question.responseCount} written ${question.responseCount === 1 ? 'response' : 'responses'}`;
+      : question.type === 'Yes/No'
+        ? `${question.agreeCount || 0} yes / ${question.disagreeCount || 0} no`
+        : question.type === 'Numerical'
+          ? `Avg ${question.average === null ? '-' : roundMetric(question.average, 1)} | Low ${question.minResponse ?? '-'} | High ${question.maxResponse ?? '-'}`
+          : `${question.responseCount} written ${question.responseCount === 1 ? 'response' : 'responses'}`;
     return `
       <tr>
         <td>${escapeHtml(question.text)} ${label}</td>
@@ -2096,10 +2135,11 @@ async function addVote(questionId, vote, userId, pseudonym) {
           'UPDATE votes SET value = $1, pseudonym = $2 WHERE id = $3',
           [JSON.stringify(vote), pseudonym, existingVote.id]
         );
-      } else if (existingVote.value === vote && questionType === 'Agreement') {
-        // Agreement votes toggle: re-selecting your current option undoes it.
-        // This must stay scoped to Agreement — for Open Ended, re-submitting the
-        // same text means "keep it", not "delete it".
+      } else if (existingVote.value === vote && (questionType === 'Agreement' || questionType === 'Yes/No')) {
+        // Agreement and Yes/No votes toggle: re-selecting your current option
+        // undoes it. This must stay scoped to those single-choice opinion types —
+        // for Open Ended, re-submitting the same text means "keep it", not
+        // "delete it".
         console.log('Voting for a option they already voted for');
         await client.query(
           'DELETE FROM votes WHERE id = $1',

--- a/server.js
+++ b/server.js
@@ -574,11 +574,15 @@ function buildSummary(discussion, questions, synthesis) {
     };
   });
 
-  const agreementSummaries = questionSummaries.filter(summary => summary.type === 'Agreement' && summary.decidedCount >= 2);
-  const topConsensus = [...agreementSummaries]
+  // Agreement and Yes/No are both single-choice opinion prompts and carry the
+  // same consensus/divisive scores, so both feed the Top Consensus / Top
+  // Divisive rankings. Each item carries its `type` so the renderer picks the
+  // matching bar (five-point vs binary).
+  const opinionSummaries = questionSummaries.filter(summary => (summary.type === 'Agreement' || summary.type === 'Yes/No') && summary.decidedCount >= 2);
+  const topConsensus = [...opinionSummaries]
     .sort((a, b) => b.consensusScore - a.consensusScore || b.responseCount - a.responseCount)
     .slice(0, 5);
-  const topDivisive = [...agreementSummaries]
+  const topDivisive = [...opinionSummaries]
     .sort((a, b) => b.divisiveScore - a.divisiveScore || b.responseCount - a.responseCount)
     .slice(0, 5);
   const facilitatorDashboard = buildFacilitatorDashboard(questionSummaries, [...participantMap.values()]);

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -228,6 +228,63 @@ test('Socket.IO adds questions and broadcasts votes with pseudonyms', async () =
   }
 });
 
+test('Yes/No questions record a single choice that toggles off when reselected', async () => {
+  const topic = uniqueTopic('yesno');
+  const author = await connectSocket();
+  const voter = await connectSocket();
+
+  try {
+    const authorInitialQuestions = waitForQuestions(author, (questions) => Array.isArray(questions), 'author join');
+    author.emit('joinDiscussion', topic);
+    await authorInitialQuestions;
+
+    const questionUpdate = waitForQuestions(
+      author,
+      (questions) => questions.length === 1 && questions[0].text === 'Ship it?',
+      'yes/no question broadcast'
+    );
+    author.emit('addQuestion', topic, {
+      text: 'Ship it?',
+      type: 'Yes/No',
+      minValue: null,
+      maxValue: null,
+      options: [],
+    });
+    const question = (await questionUpdate)[0];
+    assert.equal(question.type, 'Yes/No');
+
+    // Vote Yes.
+    const yesUpdate = waitForQuestions(
+      author,
+      (qs) => qs[0] && qs[0].votes.length === 1 && qs[0].votes[0].value === 'Yes',
+      'yes vote'
+    );
+    voter.emit('vote', topic, question.id, 'Yes', 'yn-user', 'Decider');
+    await yesUpdate;
+
+    // Switching to No replaces the single choice rather than adding a row.
+    const noUpdate = waitForQuestions(
+      author,
+      (qs) => qs[0] && qs[0].votes.length === 1 && qs[0].votes[0].value === 'No',
+      'switch to no'
+    );
+    voter.emit('vote', topic, question.id, 'No', 'yn-user', 'Decider');
+    await noUpdate;
+
+    // Re-selecting the current choice toggles it off, like Agreement votes.
+    const toggleOffUpdate = waitForQuestions(
+      author,
+      (qs) => qs[0] && qs[0].votes.length === 0,
+      'toggle off'
+    );
+    voter.emit('vote', topic, question.id, 'No', 'yn-user', 'Decider');
+    await toggleOffUpdate;
+  } finally {
+    author.disconnect();
+    voter.disconnect();
+  }
+});
+
 test('Socket.IO sanitizes display names: anonymous stores null, long names are clamped', async () => {
   const topic = uniqueTopic('names');
   const author = await connectSocket();


### PR DESCRIPTION
Adds a fifth question type, **Yes/No**, a binary opinion vote that mirrors the five-point Agreement scale (Yes reads as agreement, No as disagreement). Voters pick Yes or No with toggle-off, and results show a green/red divergence bar with Divisive/Consensus badges. Yes/No votes feed the existing agreement-style sorting (Most Agreement / Disagreement / Controversial) and are fully integrated into the live summary, facilitator dashboard divisiveness analysis, and HTML report. The opinion-groups/clustering view is intentionally left Agreement-only, since it's a Pol.is-style analysis built around the −2…+2 scale. Includes an integration test covering create → vote → switch → toggle-off.

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Yes/No questions with dedicated voting interface
  * Results display divisiveness metrics and consensus/divisive room labels
  * Vote toggling: re-selecting the same option undoes the vote
  * Visual Yes/No agreement bars show response distribution across summary and results pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->