### PR TITLE
Add moderator-selectable color themes

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,7 +9,7 @@ const App = () => {
     return (
         <Router>
             <div className="app">
-                <header className="bg-gradient-to-r from-primary to-indigo-700 text-white p-4 shadow-md">
+                <header className="bg-gradient-to-r from-primary to-primary-dark text-white p-4 shadow-md">
                     <Link to="/" className="text-white hover:text-gray-200 transition duration-300">
                         <h1 className="text-2xl font-bold">Convora</h1>
                     </Link>

--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -18,6 +18,20 @@ import { slugifyTopic } from './slugs';
 const VERSION = '0.1.8';
 console.log('Convora version:', VERSION);
 
+// Color themes a moderator can apply to a discussion. Keys and the palettes
+// they map to are defined in client/src/index.css ([data-theme] blocks) and
+// validated server-side (ALLOWED_THEMES in server.js); `swatch` is only the
+// picker dot color and mirrors each theme's primary. Keep all three in sync.
+const THEMES = [
+    { key: 'indigo', label: 'Indigo', swatch: '#4F46E5' },
+    { key: 'orange', label: 'Orange', swatch: '#FF3C00' },
+    { key: 'emerald', label: 'Emerald', swatch: '#059669' },
+    { key: 'rose', label: 'Rose', swatch: '#E11D48' },
+    { key: 'slate', label: 'Slate', swatch: '#475569' },
+];
+const THEME_KEYS = THEMES.map((t) => t.key);
+const DEFAULT_THEME = 'indigo';
+
 const QuestionTypes = {
     AGREEMENT: 'Agreement',
     NUMERICAL: 'Numerical',
@@ -112,7 +126,7 @@ const DiscussionPage = () => {
     const [presence, setPresence] = useState(0);
     const [copied, setCopied] = useState(false);
     const [adminToken, setAdminToken] = useState(null);
-    const [discussionState, setDiscussionState] = useState({ locked: false, hasModerator: false });
+    const [discussionState, setDiscussionState] = useState({ locked: false, hasModerator: false, theme: DEFAULT_THEME });
     const [similarPrompt, setSimilarPrompt] = useState(null);
     const [adminLinkCopied, setAdminLinkCopied] = useState(false);
     // Id of the question a moderator is currently editing inline (null when none).
@@ -132,6 +146,7 @@ const DiscussionPage = () => {
 
     const isAdmin = !!adminToken;
     const { locked } = discussionState;
+    const theme = THEME_KEYS.includes(discussionState.theme) ? discussionState.theme : DEFAULT_THEME;
     const discussionTitle = discussion?.topic || topic;
 
     const joinUrl = typeof window !== 'undefined'
@@ -378,6 +393,10 @@ const DiscussionPage = () => {
         socket.emit('setLocked', discussionSlug, !locked, adminToken);
     };
 
+    const handleSetTheme = (themeKey) => {
+        socket.emit('setTheme', discussionSlug, themeKey, adminToken);
+    };
+
     const handleDeleteQuestion = (questionId) => {
         socket.emit('deleteQuestion', discussionSlug, questionId, adminToken);
     };
@@ -551,6 +570,17 @@ const DiscussionPage = () => {
             socket.off('moderatorGranted', handleModeratorGranted);
         };
     }, [topic, discussionSlug, handleQuestionsUpdate, handleModeratorGranted]);
+
+    // Mirror the discussion's chosen theme onto <html data-theme="..."> so the
+    // CSS-variable palette (index.css) recolors every primary/secondary class,
+    // including the app-wide header that lives outside this page. Cleared on
+    // unmount so navigating away (e.g. back to the home page) returns to the
+    // default look rather than leaving another discussion's colors stuck on.
+    useEffect(() => {
+        const root = document.documentElement;
+        root.setAttribute('data-theme', theme);
+        return () => root.removeAttribute('data-theme');
+    }, [theme]);
 
     // Tell the server which persistent user this socket is, so it can route
     // moderator grants to us. Re-sent after any reconnect so a promoted user
@@ -1134,6 +1164,27 @@ const DiscussionPage = () => {
                         >
                             {showJoinQr ? 'Hide join QR' : 'Show join QR'}
                         </button>
+                        {/* Color theme picker: clicking a swatch recolors the
+                            discussion for everyone in the room. */}
+                        <div className="flex items-center gap-1.5 pl-1" role="group" aria-label="Color theme">
+                            <span className="font-medium text-indigo-800">Theme</span>
+                            {THEMES.map((t) => (
+                                <button
+                                    key={t.key}
+                                    type="button"
+                                    onClick={() => handleSetTheme(t.key)}
+                                    title={t.label}
+                                    aria-label={`${t.label} theme`}
+                                    aria-pressed={theme === t.key}
+                                    className={`h-6 w-6 rounded-full border border-white shadow-sm transition ${
+                                        theme === t.key
+                                            ? 'ring-2 ring-offset-1 ring-gray-700'
+                                            : 'hover:scale-110'
+                                    }`}
+                                    style={{ backgroundColor: t.swatch }}
+                                />
+                            ))}
+                        </div>
                     </div>
                 ) : !discussionState.hasModerator ? (
                     <button

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -2,6 +2,52 @@
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
 
+/*
+ * Color themes. Each palette is just three RGB channel triplets (space
+ * separated so Tailwind's `rgb(var(--x) / <alpha-value>)` colors can apply
+ * opacity). A moderator picks a theme per discussion; the client mirrors the
+ * choice onto <html data-theme="..."> and every `primary`/`secondary`/
+ * `primary-dark` Tailwind class recolors instantly. The :root block is the
+ * default ("indigo") so pages with no theme set look unchanged.
+ *
+ * --color-primary       main action color (buttons, links, focus rings, bars)
+ * --color-secondary     accent used for the alternate vote-button state
+ * --color-primary-dark  darker shade for the header gradient's end stop
+ *
+ * Theme keys here MUST stay in sync with THEME_KEYS on the client
+ * (DiscussionPage.jsx) and ALLOWED_THEMES on the server (server.js).
+ */
+:root,
+[data-theme='indigo'] {
+    --color-primary: 79 70 229;     /* #4F46E5 */
+    --color-secondary: 16 185 129;  /* #10B981 */
+    --color-primary-dark: 67 56 202;/* #4338CA */
+}
+
+[data-theme='orange'] {
+    --color-primary: 255 60 0;      /* #FF3C00 */
+    --color-secondary: 13 148 136;  /* #0D9488 */
+    --color-primary-dark: 194 65 12;/* #C2410C */
+}
+
+[data-theme='emerald'] {
+    --color-primary: 5 150 105;     /* #059669 */
+    --color-secondary: 99 102 241;  /* #6366F1 */
+    --color-primary-dark: 4 120 87; /* #047857 */
+}
+
+[data-theme='rose'] {
+    --color-primary: 225 29 72;     /* #E11D48 */
+    --color-secondary: 245 158 11;  /* #F59E0B */
+    --color-primary-dark: 190 18 60;/* #BE123C */
+}
+
+[data-theme='slate'] {
+    --color-primary: 71 85 105;     /* #475569 */
+    --color-secondary: 14 165 233;  /* #0EA5E9 */
+    --color-primary-dark: 51 65 85; /* #334155 */
+}
+
 body {
     @apply bg-slate-100 text-slate-800 antialiased;
     min-height: 100vh;

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -6,9 +6,15 @@ module.exports = {
     ],
     theme: {
         extend: {
+            // Theme colors resolve from CSS custom properties so a moderator can
+            // recolor a whole discussion at runtime by swapping a single
+            // `data-theme` attribute (palettes live in index.css). The
+            // `<alpha-value>` placeholder keeps Tailwind's opacity utilities
+            // (e.g. bg-opacity-90) working against these variable-backed colors.
             colors: {
-                primary: "#4F46E5",
-                secondary: "#10B981",
+                primary: "rgb(var(--color-primary) / <alpha-value>)",
+                secondary: "rgb(var(--color-secondary) / <alpha-value>)",
+                "primary-dark": "rgb(var(--color-primary-dark) / <alpha-value>)",
             },
             fontFamily: {
                 sans: [

--- a/server.js
+++ b/server.js
@@ -2864,7 +2864,7 @@ app.post('/api/duplicate-discussion', async (req, res) => {
     // preserves whether reactions/comments were enabled (and reactions
     // revealed) rather than silently resetting them to the defaults.
     const originalDiscussionResult = await client.query(
-      'SELECT id, reactions_enabled, reactions_visible, comments_enabled FROM discussions WHERE slug = $1',
+      'SELECT id, reactions_enabled, reactions_visible, comments_enabled, theme FROM discussions WHERE slug = $1',
       [slugifyTopic(originalTopic)]
     );
 
@@ -2898,14 +2898,15 @@ app.post('/api/duplicate-discussion', async (req, res) => {
     for (let suffix = 1; suffix <= 1000; suffix += 1) {
       const newSlug = suffixSlug(baseNewSlug, suffix);
       const newDiscussionResult = await client.query(
-        `INSERT INTO discussions (topic, slug, admin_token, reactions_enabled, reactions_visible, comments_enabled)
-         VALUES ($1, $2, $3, $4, $5, $6)
+        `INSERT INTO discussions (topic, slug, admin_token, reactions_enabled, reactions_visible, comments_enabled, theme)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
          ON CONFLICT (slug) DO NOTHING
          RETURNING id, topic, slug`,
         [displayNewTopic, newSlug, newAdminToken,
           originalDiscussion.reactions_enabled,
           originalDiscussion.reactions_visible,
-          originalDiscussion.comments_enabled]
+          originalDiscussion.comments_enabled,
+          originalDiscussion.theme]
       );
 
       if (newDiscussionResult.rows.length > 0) {

--- a/server.js
+++ b/server.js
@@ -706,15 +706,25 @@ function emitPresence(topic) {
   io.to(topic).emit('presence', count);
 }
 
-// Read the lock state and whether a moderator has been claimed.
+// Color themes a moderator may apply to a discussion. Must stay in sync with
+// the [data-theme] palettes in client/src/index.css and THEME_KEYS in
+// client/src/DiscussionPage.jsx. 'indigo' is the default/original look.
+const ALLOWED_THEMES = ['indigo', 'orange', 'emerald', 'rose', 'slate'];
+const DEFAULT_THEME = 'indigo';
+
+// Read the lock state, chosen theme, and whether a moderator has been claimed.
 async function getDiscussionState(topic) {
   const slug = slugifyTopic(topic);
   const result = await pool.query(
-    'SELECT locked, admin_token IS NOT NULL AS has_moderator FROM discussions WHERE slug = $1',
+    'SELECT locked, theme, admin_token IS NOT NULL AS has_moderator FROM discussions WHERE slug = $1',
     [slug]
   );
-  if (result.rows.length === 0) return { locked: false, hasModerator: false };
-  return { locked: result.rows[0].locked === true, hasModerator: result.rows[0].has_moderator === true };
+  if (result.rows.length === 0) return { locked: false, hasModerator: false, theme: DEFAULT_THEME };
+  return {
+    locked: result.rows[0].locked === true,
+    hasModerator: result.rows[0].has_moderator === true,
+    theme: result.rows[0].theme || DEFAULT_THEME,
+  };
 }
 
 async function emitDiscussionState(topic) {
@@ -958,6 +968,28 @@ io.on('connection', (socket) => {
       await emitDiscussionState(discussionSlug);
     } catch (error) {
       console.error('Error setting lock state:', error);
+      socket.emit('error', { message: 'Failed to update discussion' });
+    }
+  });
+
+  // Moderator-only: set the discussion's color theme. The new theme rides the
+  // discussionState broadcast, so every connected participant recolors at once.
+  socket.on('setTheme', async (topic, theme, token) => {
+    const discussionSlug = slugifyTopic(topic);
+    try {
+      const discussionId = await verifyAdmin(discussionSlug, token);
+      if (!discussionId) {
+        socket.emit('error', { message: 'Not authorized to moderate this discussion.' });
+        return;
+      }
+      if (!ALLOWED_THEMES.includes(theme)) {
+        socket.emit('error', { message: 'Unknown theme.' });
+        return;
+      }
+      await pool.query('UPDATE discussions SET theme = $1 WHERE id = $2', [theme, discussionId]);
+      await emitDiscussionState(discussionSlug);
+    } catch (error) {
+      console.error('Error setting theme:', error);
       socket.emit('error', { message: 'Failed to update discussion' });
     }
   });
@@ -1884,6 +1916,8 @@ async function migrateBrainstormInteractions() {
 async function migrateModerationAndDedup() {
   await pool.query('ALTER TABLE discussions ADD COLUMN IF NOT EXISTS admin_token TEXT');
   await pool.query('ALTER TABLE discussions ADD COLUMN IF NOT EXISTS locked BOOLEAN NOT NULL DEFAULT FALSE');
+  // Per-discussion color theme the moderator picks; 'indigo' is the original look.
+  await pool.query("ALTER TABLE discussions ADD COLUMN IF NOT EXISTS theme TEXT NOT NULL DEFAULT 'indigo'");
   await pool.query('ALTER TABLE questions ADD COLUMN IF NOT EXISTS pinned BOOLEAN NOT NULL DEFAULT FALSE');
 
   try {

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -1290,11 +1290,16 @@ test('Duplicating a discussion preserves brainstorm interaction flags', async ()
     mod.emit('setReactionKeys', topic, ['crux', 'follows'], token);
     await narrowed;
 
+    // And pick a non-default color theme; the duplicate should keep it too.
+    const themed = waitForEvent(mod, 'discussionState', (s) => s.theme === 'orange');
+    mod.emit('setTheme', topic, 'orange', token);
+    await themed;
+
     const newTopic = uniqueTopic('brainstorm-dup-copy');
     const dup = await jsonRequest('POST', '/api/duplicate-discussion', { originalTopic: topic, newTopic });
     assert.equal(dup.status, 200);
 
-    // The duplicate must keep the same flags and reaction set, not reset to defaults.
+    // The duplicate must keep the same flags, reaction set, and theme, not reset to defaults.
     const copy = await connectSocket();
     try {
       const copyQuestions = waitForQuestions(
@@ -1305,7 +1310,9 @@ test('Duplicating a discussion preserves brainstorm interaction flags', async ()
       assert.equal(q.reactionsEnabled, true);
       assert.equal(q.reactionsVisible, false);
       assert.equal(q.commentsEnabled, true);
-      assert.deepEqual((await copyState).reactionKeys, ['crux', 'follows']);
+      const state = await copyState;
+      assert.deepEqual(state.reactionKeys, ['crux', 'follows']);
+      assert.equal(state.theme, 'orange');
     } finally {
       copy.disconnect();
     }

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -588,6 +588,70 @@ test('a moderator can promote a participant, granting them working controls', as
   }
 });
 
+test('a moderator sets the discussion color theme and it broadcasts to everyone', async () => {
+  const topic = uniqueTopic('theme');
+  const mod = await connectSocket();
+  const guest = await connectSocket();
+
+  try {
+    mod.emit('joinDiscussion', topic);
+    guest.emit('joinDiscussion', topic);
+    const token = await claimModerator(mod, topic);
+
+    // A fresh discussion defaults to the original 'indigo' look.
+    const claimed = await waitForEvent(guest, 'discussionState', (s) => s.hasModerator === true);
+    assert.equal(claimed.theme, 'indigo');
+
+    // The moderator switches theme; every participant receives the new value.
+    const themed = waitForEvent(guest, 'discussionState', (s) => s.theme === 'orange');
+    mod.emit('setTheme', topic, 'orange', token);
+    assert.equal((await themed).theme, 'orange');
+
+    // An unknown theme is rejected (error to the sender) and never broadcast.
+    const rejected = waitForEvent(mod, 'error', (e) => /theme/i.test(e.message));
+    mod.emit('setTheme', topic, 'chartreuse', token);
+    await rejected;
+
+    // The stored theme is unchanged: a fresh join still reports 'orange'.
+    const rejoin = await connectSocket();
+    try {
+      rejoin.emit('joinDiscussion', topic);
+      const state = await waitForEvent(rejoin, 'discussionState');
+      assert.equal(state.theme, 'orange');
+    } finally {
+      rejoin.disconnect();
+    }
+  } finally {
+    mod.disconnect();
+    guest.disconnect();
+  }
+});
+
+test('a non-moderator cannot set the discussion theme', async () => {
+  const topic = uniqueTopic('theme-deny');
+  await jsonRequest('POST', '/api/discussions', { topic });
+
+  const stranger = await connectSocket();
+  try {
+    stranger.emit('joinDiscussion', topic);
+    const rejected = waitForEvent(stranger, 'error', (e) => /authoriz/i.test(e.message));
+    stranger.emit('setTheme', topic, 'orange', 'bogus-token');
+    await rejected;
+
+    // The theme stays at the default for everyone who joins afterward.
+    const observer = await connectSocket();
+    try {
+      observer.emit('joinDiscussion', topic);
+      const state = await waitForEvent(observer, 'discussionState');
+      assert.equal(state.theme, 'indigo');
+    } finally {
+      observer.disconnect();
+    }
+  } finally {
+    stranger.disconnect();
+  }
+});
+
 test('a non-moderator cannot list or promote participants', async () => {
   const topic = uniqueTopic('promote-deny');
   await jsonRequest('POST', '/api/discussions', { topic });


### PR DESCRIPTION
## What

Moderators can now recolor a whole discussion for everyone in the room. A swatch picker in the moderator bar offers five palettes:

- **Indigo** — the original look, and the default for every existing/new discussion
- **Orange**
- **Emerald**
- **Rose**
- **Slate**

The pick is per-discussion, persists, and propagates live to all participants.

## How

- **Tailwind colors are now CSS-variable backed.** `primary` and `secondary` resolve from CSS custom properties (plus a new `primary-dark` for the header gradient), so every existing `bg-primary`/`text-primary`/`bg-secondary`/`ring-primary` class re-themes with zero per-component edits. Each palette is a `[data-theme="…"]` block in `index.css`; `:root` holds the default so themeless pages (home, summary) look unchanged.
- **Persistence + broadcast.** New `theme` column on `discussions` (idempotent migration, defaults to `indigo`). The value rides the existing `discussionState` socket broadcast, so locking and theming share one channel. The client mirrors it onto `<html data-theme="…">` and clears it on unmount so navigating away returns to the default.
- **Server guard.** `setTheme` is moderator-gated via `verifyAdmin` and validates against an allowed-theme list, mirroring the existing `setLocked` handler. The theme key list is kept in sync across `index.css`, `DiscussionPage.jsx`, and `server.js`.

## Tests

- Added integration tests: the moderator→all-participants broadcast path (including rejection of an unknown theme), and that a non-moderator cannot change the theme.
- Full suite: **34/34 passing**. Client build is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Moderators can now customize discussion appearance by selecting from multiple color themes (indigo, orange, emerald, rose, and slate)
  * Selected themes persist and sync across all discussion participants
  * Theme selections are preserved when discussions are duplicated

* **Style**
  * Updated default header color styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->