### PR TITLE
Add moderator-only questions toggle

### DIFF
--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -112,7 +112,7 @@ const DiscussionPage = () => {
     const [presence, setPresence] = useState(0);
     const [copied, setCopied] = useState(false);
     const [adminToken, setAdminToken] = useState(null);
-    const [discussionState, setDiscussionState] = useState({ locked: false, hasModerator: false });
+    const [discussionState, setDiscussionState] = useState({ locked: false, moderatorOnly: false, hasModerator: false });
     const [similarPrompt, setSimilarPrompt] = useState(null);
     const [adminLinkCopied, setAdminLinkCopied] = useState(false);
     // Id of the question a moderator is currently editing inline (null when none).
@@ -131,7 +131,7 @@ const DiscussionPage = () => {
     const [myBrainstorm, setMyBrainstorm] = useState({ ratings: {}, reactions: {} });
 
     const isAdmin = !!adminToken;
-    const { locked } = discussionState;
+    const { locked, moderatorOnly } = discussionState;
     const discussionTitle = discussion?.topic || topic;
 
     const joinUrl = typeof window !== 'undefined'
@@ -378,6 +378,10 @@ const DiscussionPage = () => {
         socket.emit('setLocked', discussionSlug, !locked, adminToken);
     };
 
+    const handleToggleModeratorOnly = () => {
+        socket.emit('setModeratorOnly', discussionSlug, !moderatorOnly, adminToken);
+    };
+
     const handleDeleteQuestion = (questionId) => {
         socket.emit('deleteQuestion', discussionSlug, questionId, adminToken);
     };
@@ -615,12 +619,14 @@ const DiscussionPage = () => {
     const submitQuestion = (question, force) => {
         try {
             setError(null);
-            socket.emit('addQuestion', discussionSlug, question, force, (resp) => {
+            socket.emit('addQuestion', discussionSlug, question, force, adminToken, (resp) => {
                 if (resp && resp.added) {
                     setNewQuestion('');
                     setQuestionType(QuestionTypes.AGREEMENT);
                     setMinValue(0);
                     setMaxValue(100);
+                } else if (resp && resp.reason === 'moderator_only') {
+                    setError('Only the moderator can add questions right now.');
                 }
             });
         } catch (error) {
@@ -1103,6 +1109,15 @@ const DiscussionPage = () => {
                             {locked ? 'Unlock discussion' : 'Lock discussion'}
                         </button>
                         <button
+                            onClick={handleToggleModeratorOnly}
+                            className="px-3 py-1 rounded bg-white border border-indigo-300 text-indigo-700 hover:bg-indigo-100"
+                            title={moderatorOnly
+                                ? 'Anyone can add questions'
+                                : 'Only you can add questions; everyone can still vote'}
+                        >
+                            {moderatorOnly ? 'Open questions to everyone' : 'Only I can add questions'}
+                        </button>
+                        <button
                             onClick={handleCopyAdminLink}
                             className="px-3 py-1 rounded bg-white border border-indigo-300 text-indigo-700 hover:bg-indigo-100"
                             title="Anyone with this link becomes a moderator"
@@ -1224,7 +1239,16 @@ const DiscussionPage = () => {
                 </div>
             )}
 
-            {!locked && (
+            {/* When the moderator has restricted question-asking, let participants
+                know why they can't add one (voting stays open). Hidden from the
+                moderator, who keeps the form and the toggle. */}
+            {!locked && moderatorOnly && !isAdmin && (
+                <div className="mb-8 bg-indigo-50 border border-indigo-200 text-indigo-800 rounded-md p-3 text-center">
+                    Only the moderator can add questions right now. You can still vote on the ones below.
+                </div>
+            )}
+
+            {!locked && (!moderatorOnly || isAdmin) && (
             <div className="bg-white shadow-lg rounded-lg p-6 mb-8">
                 <input
                     type="text"

--- a/server.js
+++ b/server.js
@@ -706,15 +706,20 @@ function emitPresence(topic) {
   io.to(topic).emit('presence', count);
 }
 
-// Read the lock state and whether a moderator has been claimed.
+// Read the lock state, the moderator-only-questions state, and whether a
+// moderator has been claimed.
 async function getDiscussionState(topic) {
   const slug = slugifyTopic(topic);
   const result = await pool.query(
-    'SELECT locked, admin_token IS NOT NULL AS has_moderator FROM discussions WHERE slug = $1',
+    'SELECT locked, moderator_only_questions, admin_token IS NOT NULL AS has_moderator FROM discussions WHERE slug = $1',
     [slug]
   );
-  if (result.rows.length === 0) return { locked: false, hasModerator: false };
-  return { locked: result.rows[0].locked === true, hasModerator: result.rows[0].has_moderator === true };
+  if (result.rows.length === 0) return { locked: false, moderatorOnly: false, hasModerator: false };
+  return {
+    locked: result.rows[0].locked === true,
+    moderatorOnly: result.rows[0].moderator_only_questions === true,
+    hasModerator: result.rows[0].has_moderator === true,
+  };
 }
 
 async function emitDiscussionState(topic) {
@@ -776,7 +781,7 @@ io.on('connection', (socket) => {
     emitPresence(roomToLeave);
   });
 
-  socket.on('addQuestion', async (topic, question, force, ack) => {
+  socket.on('addQuestion', async (topic, question, force, token, ack) => {
     const discussionSlug = slugifyTopic(topic);
     console.log('Received addQuestion event');
     console.log('topic:', discussionSlug);
@@ -794,6 +799,18 @@ io.on('connection', (socket) => {
         socket.emit('error', { message: 'This discussion is locked.' });
         reply({ added: false, reason: 'locked' });
         return;
+      }
+
+      // When the discussion is moderator-only, reject submissions from anyone who
+      // can't prove they moderate it. Voting stays open — this gates only new
+      // questions, so a moderator can curate the agenda then open it to the floor.
+      if (await isModeratorOnlyQuestions(discussionSlug)) {
+        const discussionId = await verifyAdmin(discussionSlug, token);
+        if (!discussionId) {
+          socket.emit('error', { message: 'Only the moderator can add questions right now.' });
+          reply({ added: false, reason: 'moderator_only' });
+          return;
+        }
       }
 
       // Surface a near-duplicate so the submitter can vote on the existing
@@ -958,6 +975,22 @@ io.on('connection', (socket) => {
       await emitDiscussionState(discussionSlug);
     } catch (error) {
       console.error('Error setting lock state:', error);
+      socket.emit('error', { message: 'Failed to update discussion' });
+    }
+  });
+
+  socket.on('setModeratorOnly', async (topic, moderatorOnly, token) => {
+    const discussionSlug = slugifyTopic(topic);
+    try {
+      const discussionId = await verifyAdmin(discussionSlug, token);
+      if (!discussionId) {
+        socket.emit('error', { message: 'Not authorized to moderate this discussion.' });
+        return;
+      }
+      await pool.query('UPDATE discussions SET moderator_only_questions = $1 WHERE id = $2', [!!moderatorOnly, discussionId]);
+      await emitDiscussionState(discussionSlug);
+    } catch (error) {
+      console.error('Error setting moderator-only state:', error);
       socket.emit('error', { message: 'Failed to update discussion' });
     }
   });
@@ -1814,12 +1847,16 @@ async function migrateBrainstormInteractions() {
   console.log('Brainstorm interactions migration completed');
 }
 
-// Moderation columns: a per-discussion admin token, a discussion lock, and a
-// per-question pin flag. Plus the pg_trgm extension for near-duplicate
-// statement detection. All idempotent.
+// Moderation columns: a per-discussion admin token, a discussion lock, a
+// moderator-only-questions flag, and a per-question pin flag. Plus the pg_trgm
+// extension for near-duplicate statement detection. All idempotent.
 async function migrateModerationAndDedup() {
   await pool.query('ALTER TABLE discussions ADD COLUMN IF NOT EXISTS admin_token TEXT');
   await pool.query('ALTER TABLE discussions ADD COLUMN IF NOT EXISTS locked BOOLEAN NOT NULL DEFAULT FALSE');
+  // When true, only moderators may add questions; everyone can still vote. Lets a
+  // moderator set the agenda ("here are the questions") and open it to the floor
+  // at will, independent of the all-or-nothing `locked` flag.
+  await pool.query('ALTER TABLE discussions ADD COLUMN IF NOT EXISTS moderator_only_questions BOOLEAN NOT NULL DEFAULT FALSE');
   await pool.query('ALTER TABLE questions ADD COLUMN IF NOT EXISTS pinned BOOLEAN NOT NULL DEFAULT FALSE');
 
   try {
@@ -2081,6 +2118,13 @@ async function isDiscussionLocked(topic) {
   const slug = slugifyTopic(topic);
   const result = await pool.query('SELECT locked FROM discussions WHERE slug = $1', [slug]);
   return result.rows.length > 0 ? result.rows[0].locked === true : false;
+}
+
+// Whether only moderators may currently add questions to a discussion.
+async function isModeratorOnlyQuestions(topic) {
+  const slug = slugifyTopic(topic);
+  const result = await pool.query('SELECT moderator_only_questions FROM discussions WHERE slug = $1', [slug]);
+  return result.rows.length > 0 ? result.rows[0].moderator_only_questions === true : false;
 }
 
 // Confirm a question belongs to the given topic and report whether that

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -834,6 +834,101 @@ test('Brainstorm ratings, reactions, and comments are rejected once the discussi
   }
 });
 
+test('moderator-only mode lets only moderators add questions while voting stays open', async () => {
+  const topic = uniqueTopic('mod-only-questions');
+  const mod = await connectSocket();
+  const participant = await connectSocket();
+
+  try {
+    mod.emit('joinDiscussion', topic);
+    participant.emit('joinDiscussion', topic);
+    const token = await claimModerator(mod, topic);
+
+    // Turn on moderator-only questions and wait for the state to broadcast.
+    const restricted = waitForEvent(participant, 'discussionState', (s) => s.moderatorOnly === true);
+    mod.emit('setModeratorOnly', topic, true, token);
+    await restricted;
+
+    // A participant with no moderator token is bounced...
+    const rejected = await emitWithAck(
+      participant,
+      'addQuestion',
+      topic,
+      { text: 'Can I ask this?', type: 'Agreement', minValue: null, maxValue: null, options: [] },
+      false,
+      null
+    );
+    assert.equal(rejected.added, false, 'participant submission must be rejected');
+    assert.equal(rejected.reason, 'moderator_only');
+
+    // ...but the moderator can add a question with their token. Register the
+    // listener before emitting: the server broadcasts 'questions' before it acks.
+    const questionAdded = waitForQuestions(mod, (qs) => qs.length === 1, 'moderator question added');
+    const modAdded = await emitWithAck(
+      mod,
+      'addQuestion',
+      topic,
+      { text: 'Moderator agenda item', type: 'Agreement', minValue: null, maxValue: null, options: [] },
+      false,
+      token
+    );
+    assert.equal(modAdded.added, true, 'moderator submission must be accepted');
+
+    const questions = await questionAdded;
+    const questionId = questions[0].id;
+    assert.equal(questions[0].text, 'Moderator agenda item');
+
+    // Voting stays open for everyone even while questions are restricted.
+    const voted = waitForQuestions(mod, (qs) => qs[0] && qs[0].votes.length === 1, 'participant vote recorded');
+    participant.emit('vote', topic, questionId, 'Agree', 'user-voter', 'Voter');
+    await voted;
+
+    // Reopening lets participants add questions again.
+    const opened = waitForEvent(participant, 'discussionState', (s) => s.moderatorOnly === false);
+    mod.emit('setModeratorOnly', topic, false, token);
+    await opened;
+
+    const accepted = await emitWithAck(
+      participant,
+      'addQuestion',
+      topic,
+      { text: 'Now I can ask', type: 'Agreement', minValue: null, maxValue: null, options: [] },
+      false,
+      null
+    );
+    assert.equal(accepted.added, true, 'participant submission must be accepted once reopened');
+  } finally {
+    mod.disconnect();
+    participant.disconnect();
+  }
+});
+
+test('setModeratorOnly rejects callers without a valid moderator token', async () => {
+  const topic = uniqueTopic('mod-only-auth');
+  const mod = await connectSocket();
+  const intruder = await connectSocket();
+
+  try {
+    mod.emit('joinDiscussion', topic);
+    intruder.emit('joinDiscussion', topic);
+    await claimModerator(mod, topic);
+
+    // An attempt with a bogus token must not change the discussion's state.
+    const errored = waitForEvent(intruder, 'error');
+    intruder.emit('setModeratorOnly', topic, true, 'not-a-real-token');
+    await errored;
+
+    // beforeEach truncates, and only the moderator's claim created a discussion,
+    // so the single row reflects whether the bogus token managed to flip the flag.
+    const state = await pool.query('SELECT moderator_only_questions FROM discussions');
+    assert.equal(state.rows.length, 1);
+    assert.equal(state.rows[0].moderator_only_questions, false);
+  } finally {
+    mod.disconnect();
+    intruder.disconnect();
+  }
+});
+
 test('Renaming updates stored comment pseudonyms, and comment tokens are namespaced', async () => {
   const topic = uniqueTopic('brainstorm-rename');
   const mod = await connectSocket();


### PR DESCRIPTION
## What & why

Answers a user request: *"Is there a way for the moderator to be the only one to ask questions?"* Previously the only control was the all-or-nothing **Lock discussion** flag, which closes both voting *and* submissions for everyone.

This adds a separate **moderator-only questions** mode the moderator can flip on and off at any time:

- **On:** only moderators can add questions; everyone can still vote and react.
- **Off:** open to the floor (the default, unchanged behavior).

So a moderator can curate the agenda ("here are the questions I want us to discuss") and then open it up when they're ready — independent of the lock.

## Changes

- **DB:** new per-discussion `moderator_only_questions` column via an idempotent migration (mirrors the existing `locked` migration). Broadcast to clients on `discussionState`.
- **Backend:** `addQuestion` now requires a valid moderator token when the mode is on (rejects others with reason `moderator_only`); voting paths are untouched. New `setModeratorOnly` socket event, `verifyAdmin`-gated like `setLocked`.
- **Frontend:** a toggle in the moderator bar ("Only I can add questions" / "Open questions to everyone"), the submission form hidden for non-moderators while restricted, and a notice telling participants they can still vote.

## Tests

Added two integration tests:
1. Moderator-only mode rejects participant submissions, accepts the moderator's, and keeps voting open; reopening restores participant submissions.
2. `setModeratorOnly` rejects callers without a valid moderator token.

Full suite passes (30/30) and the client build is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)