### PR TITLE
Label histogram axes on Numerical question results

### DIFF
--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -2211,20 +2211,45 @@ const NumericalResults = ({ question, minValue, maxValue }) => {
     });
     const tallestBin = Math.max(...bins);
 
+    // Up to three integer y-axis ticks (top, middle, baseline) positioned
+    // proportionally so they line up with the bar heights.
+    const yTicks = tallestBin <= 1
+        ? [1, 0]
+        : [...new Set([tallestBin, Math.round(tallestBin / 2), 0])].sort((a, b) => b - a);
+
     return (
         <div className="mb-2">
             <div className="text-sm text-gray-600 mb-2">
                 {total} {total === 1 ? 'response' : 'responses'} · average <span className="font-semibold">{average.toFixed(1)}</span>
             </div>
-            <div className="flex items-end gap-1 h-16">
-                {bins.map((count, i) => (
-                    <div
-                        key={i}
-                        className="flex-1 bg-primary rounded-t"
-                        style={{ height: tallestBin > 0 ? `${(count / tallestBin) * 100}%` : '0%' }}
-                        title={`${count} ${count === 1 ? 'response' : 'responses'}`}
-                    />
-                ))}
+            <div className="flex gap-1">
+                {/* Y-axis count labels */}
+                <div className="relative w-6 h-16 text-[10px] leading-none text-gray-400">
+                    {yTicks.map(t => (
+                        <span
+                            key={t}
+                            className="absolute right-0 -translate-y-1/2"
+                            style={{ bottom: `${(t / tallestBin) * 100}%` }}
+                        >
+                            {t}
+                        </span>
+                    ))}
+                </div>
+                <div className="flex items-end gap-1 h-16 flex-1">
+                    {bins.map((count, i) => (
+                        <div
+                            key={i}
+                            className="flex-1 bg-primary rounded-t"
+                            style={{ height: tallestBin > 0 ? `${(count / tallestBin) * 100}%` : '0%' }}
+                            title={`${count} ${count === 1 ? 'response' : 'responses'}`}
+                        />
+                    ))}
+                </div>
+            </div>
+            {/* X-axis min/max labels, offset to align with the bars */}
+            <div className="ml-7 flex justify-between text-[10px] text-gray-400 mt-1">
+                <span>{minValue}</span>
+                <span>{maxValue}</span>
             </div>
         </div>
     );

--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -2223,17 +2223,23 @@ const NumericalResults = ({ question, minValue, maxValue }) => {
                 {total} {total === 1 ? 'response' : 'responses'} · average <span className="font-semibold">{average.toFixed(1)}</span>
             </div>
             <div className="flex gap-1">
-                {/* Y-axis count labels */}
+                {/* Y-axis count labels. Each is anchored by its bottom edge at the
+                    tick's proportional height, then nudged vertically so it stays
+                    inside the box: the top tick hangs down from the top line, the
+                    baseline tick sits on the bottom, and middle ticks are centered. */}
                 <div className="relative w-6 h-16 text-[10px] leading-none text-gray-400">
-                    {yTicks.map(t => (
-                        <span
-                            key={t}
-                            className="absolute right-0 -translate-y-1/2"
-                            style={{ bottom: `${(t / tallestBin) * 100}%` }}
-                        >
-                            {t}
-                        </span>
-                    ))}
+                    {yTicks.map((t, idx) => {
+                        const nudge = idx === 0 ? 'translate-y-full' : t === 0 ? '' : 'translate-y-1/2';
+                        return (
+                            <span
+                                key={t}
+                                className={`absolute right-0 ${nudge}`}
+                                style={{ bottom: `${(t / tallestBin) * 100}%` }}
+                            >
+                                {t}
+                            </span>
+                        );
+                    })}
                 </div>
                 <div className="flex items-end gap-1 h-16 flex-1">
                     {bins.map((count, i) => (


### PR DESCRIPTION
The Numerical-question results histogram previously had no axes: per-bucket counts were only visible on hover, and the value range was unlabeled. This adds a left-hand y-axis with up to three integer count ticks (top, midpoint, baseline) positioned proportionally so they align with the bar heights, plus min/max labels on the x-axis. Counts are now readable at a glance without hovering. Verified with `npm run build` and ESLint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)