### PR TITLE
Remove the Written Response Synthesis feature

### DIFF
--- a/client/src/SummaryPage.jsx
+++ b/client/src/SummaryPage.jsx
@@ -242,8 +242,6 @@ const SummaryPage = () => {
                 />
             </section>
 
-            <SynthesisPanel synthesis={summary.synthesis} />
-
             <section className="mt-8">
                 <h2 className="text-2xl font-bold mb-4 text-gray-800">Question Counts</h2>
                 <div className="space-y-4">
@@ -580,100 +578,6 @@ const YesNoBar = ({ optionCounts, total }) => {
 YesNoBar.propTypes = {
     optionCounts: PropTypes.objectOf(PropTypes.number).isRequired,
     total: PropTypes.number.isRequired,
-};
-
-const SynthesisPanel = ({ synthesis }) => (
-    <section className="bg-white shadow rounded-lg p-6">
-        <div className="flex items-center justify-between gap-4 mb-4">
-            <h2 className="text-2xl font-bold text-gray-800">Written Response Synthesis</h2>
-            {synthesis?.mode && (
-                <span className="px-2 py-1 text-xs font-semibold rounded-full bg-gray-100 text-gray-700">
-                    {synthesis.mode === 'llm' ? 'LLM' : 'Auto'}
-                </span>
-            )}
-        </div>
-
-        {!synthesis ? (
-            <p className="text-sm text-gray-500">No open-ended responses yet.</p>
-        ) : synthesis.mode === 'llm' ? (
-            <div className="space-y-4">
-                {synthesis.synthesis && <p className="text-gray-800">{synthesis.synthesis}</p>}
-                <SynthesisList title="Common Themes" items={synthesis.commonThemes} />
-                <SynthesisList title="Unresolved Questions" items={synthesis.unresolvedQuestions} />
-                <SynthesisList title="Notable Divergences" items={synthesis.notableDivergences} />
-            </div>
-        ) : (
-            <div className="space-y-4">
-                <p className="text-gray-800">{synthesis.text}</p>
-                {synthesis.llmError && <p className="text-sm text-amber-700">{synthesis.llmError}</p>}
-                {synthesis.highlights?.length > 0 && (
-                    <div>
-                        <h3 className="font-semibold mb-2 text-gray-800">Prompts</h3>
-                        <ul className="list-disc pl-5 text-gray-700 space-y-1">
-                            {synthesis.highlights.map(item => (
-                                <li key={item.question}>{item.question}: {item.responseCount}</li>
-                            ))}
-                        </ul>
-                    </div>
-                )}
-                {synthesis.excerpts?.length > 0 && (
-                    <div>
-                        <h3 className="font-semibold mb-2 text-gray-800">Representative Excerpts</h3>
-                        <ul className="space-y-2">
-                            {synthesis.excerpts.map((item, index) => (
-                                <li key={`${item.question}-${index}`} className="bg-gray-50 rounded-md p-3">
-                                    <div className="text-xs font-semibold text-gray-500 mb-1">{item.question}</div>
-                                    <div className="text-gray-800">{item.excerpt}</div>
-                                </li>
-                            ))}
-                        </ul>
-                    </div>
-                )}
-            </div>
-        )}
-    </section>
-);
-
-SynthesisPanel.propTypes = {
-    synthesis: PropTypes.shape({
-        mode: PropTypes.string,
-        text: PropTypes.string,
-        llmError: PropTypes.string,
-        synthesis: PropTypes.string,
-        commonThemes: PropTypes.array,
-        unresolvedQuestions: PropTypes.array,
-        notableDivergences: PropTypes.array,
-        highlights: PropTypes.arrayOf(PropTypes.shape({
-            question: PropTypes.string.isRequired,
-            responseCount: PropTypes.number.isRequired,
-        })),
-        excerpts: PropTypes.arrayOf(PropTypes.shape({
-            question: PropTypes.string.isRequired,
-            excerpt: PropTypes.string.isRequired,
-        })),
-    }),
-};
-
-const SynthesisList = ({ title, items }) => {
-    if (!Array.isArray(items) || items.length === 0) {
-        return null;
-    }
-
-    return (
-        <div>
-            <h3 className="font-semibold mb-2 text-gray-800">{title}</h3>
-            <ul className="list-disc pl-5 text-gray-700 space-y-1">
-                {items.map((item, index) => (
-                    <li key={`${title}-${index}`}>{typeof item === 'string' ? item : JSON.stringify(item)}</li>
-                ))}
-            </ul>
-        </div>
-    );
-};
-
-SynthesisList.propTypes = {
-    title: PropTypes.string.isRequired,
-    items: PropTypes.array,
 };
 
 const QuestionSummary = ({ question }) => (

--- a/server.js
+++ b/server.js
@@ -143,54 +143,6 @@ function getQuestionRange(question) {
   };
 }
 
-function extractResponseText(data) {
-  if (typeof data.output_text === 'string') {
-    return data.output_text;
-  }
-
-  const contentItems = (data.output || [])
-    .flatMap(item => Array.isArray(item.content) ? item.content : []);
-  const text = contentItems
-    .map(item => typeof item.text === 'string' ? item.text : '')
-    .filter(Boolean)
-    .join('\n')
-    .trim();
-
-  return text || null;
-}
-
-function buildDeterministicSynthesis(writtenResponses) {
-  if (writtenResponses.length === 0) {
-    return null;
-  }
-
-  const byQuestion = writtenResponses.reduce((acc, response) => {
-    if (!acc.has(response.questionText)) {
-      acc.set(response.questionText, []);
-    }
-    acc.get(response.questionText).push(response.value);
-    return acc;
-  }, new Map());
-
-  const longestResponses = [...writtenResponses]
-    .sort((a, b) => b.value.length - a.value.length)
-    .slice(0, 3)
-    .map(response => ({
-      question: response.questionText,
-      excerpt: response.value.length > 180 ? `${response.value.slice(0, 177)}...` : response.value,
-    }));
-
-  return {
-    mode: 'deterministic',
-    text: `${writtenResponses.length} written ${writtenResponses.length === 1 ? 'response' : 'responses'} across ${byQuestion.size} ${byQuestion.size === 1 ? 'prompt' : 'prompts'}.`,
-    highlights: [...byQuestion.entries()].map(([question, responses]) => ({
-      question,
-      responseCount: responses.length,
-    })),
-    excerpts: longestResponses,
-  };
-}
-
 function roundMetric(value, digits = 2) {
   if (!Number.isFinite(value)) {
     return 0;
@@ -375,7 +327,7 @@ function buildFacilitatorDashboard(questionSummaries, participantStats) {
     recommendedNextActions.push('Balance the room by inviting quieter visible participants to respond before closing.');
   }
   if (recommendedNextActions.length === 0) {
-    recommendedNextActions.push('Review the consensus and written synthesis, then close with owners and next steps.');
+    recommendedNextActions.push('Review the consensus, then close with owners and next steps.');
   }
 
   return {
@@ -389,64 +341,7 @@ function buildFacilitatorDashboard(questionSummaries, participantStats) {
   };
 }
 
-async function buildLlmSynthesis(writtenResponses) {
-  if (
-    writtenResponses.length === 0 ||
-    process.env.ENABLE_LLM_SYNTHESIS !== 'true' ||
-    !process.env.OPENAI_API_KEY
-  ) {
-    return null;
-  }
-
-  const payload = writtenResponses.slice(0, 80).map(response => ({
-    question: response.questionText,
-    response: response.value,
-  }));
-
-  const response = await fetch('https://api.openai.com/v1/responses', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-    },
-    body: JSON.stringify({
-      model: process.env.OPENAI_MODEL || 'gpt-4.1-mini',
-      input: [
-        {
-          role: 'system',
-          content: 'Summarize open-ended discussion responses for a read-only post-discussion report. Be concise, neutral, and preserve unresolved tensions.',
-        },
-        {
-          role: 'user',
-          content: `Return JSON with keys synthesis, commonThemes, unresolvedQuestions, and notableDivergences. Responses: ${JSON.stringify(payload)}`,
-        },
-      ],
-      text: {
-        format: {
-          type: 'json_object',
-        },
-      },
-    }),
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    throw new Error(`LLM synthesis failed: ${response.status} ${errorText}`);
-  }
-
-  const data = await response.json();
-  const outputText = extractResponseText(data);
-  if (!outputText) {
-    return null;
-  }
-
-  return {
-    mode: 'llm',
-    ...JSON.parse(outputText),
-  };
-}
-
-function buildSummary(discussion, questions, synthesis) {
+function buildSummary(discussion, questions) {
   const participantIds = new Set();
   const participantMap = new Map();
   const typeCounts = {};
@@ -603,17 +498,12 @@ function buildSummary(discussion, questions, synthesis) {
     topConsensus,
     topDivisive,
     facilitatorDashboard,
-    synthesis,
     questions: questionSummaries,
   };
 }
 
 function renderReportHtml(summary) {
   const dashboard = summary.facilitatorDashboard || {};
-  const synthesis = summary.synthesis;
-  const synthesisText = synthesis?.mode === 'llm'
-    ? synthesis.synthesis
-    : synthesis?.text;
   const generatedAt = new Date().toLocaleString();
 
   const renderList = (items, emptyText, renderItem) => {
@@ -715,11 +605,6 @@ function renderReportHtml(summary) {
         <h2>Unanswered Prompts</h2>
         ${renderList(dashboard.unansweredPrompts, 'Every prompt has at least one response.', item => `<li>${escapeHtml(item.text)} <span class="muted">(${escapeHtml(item.type)})</span></li>`)}
       </div>
-    </section>
-
-    <section>
-      <h2>Written Response Synthesis</h2>
-      <p>${escapeHtml(synthesisText || 'No open-ended responses yet.')}</p>
     </section>
 
     <section>
@@ -2652,7 +2537,7 @@ app.get('/api/discussions', async (req, res) => {
   }
 });
 
-async function getDiscussionSummary(topic, options = {}) {
+async function getDiscussionSummary(topic) {
   const discussion = await getDiscussionBySlug(topic);
   if (!discussion) {
     return null;
@@ -2663,52 +2548,13 @@ async function getDiscussionSummary(topic, options = {}) {
   // collapse). buildFacilitatorDashboard re-keys to participant-N before any
   // of this reaches a client, so the raw ids never leave the server.
   const questions = await getQuestions(topic, { includeUserIds: true });
-  const writtenResponses = questions
-    .filter(question => question.type === 'Open Ended' || question.type === 'Brainstorm')
-    .flatMap(question => (question.votes || [])
-      .map(vote => ({
-        questionId: question.id,
-        questionText: question.text,
-        questionType: question.type,
-        pseudonym: vote.pseudonym || 'Anonymous',
-        value: String(parseStoredVoteValue(vote.value) || '').trim(),
-      }))
-      .filter(response => response.value !== ''));
 
-  let synthesis = buildDeterministicSynthesis(writtenResponses);
-  if (options.llm) {
-    if (
-      writtenResponses.length > 0 &&
-      (process.env.ENABLE_LLM_SYNTHESIS !== 'true' || !process.env.OPENAI_API_KEY)
-    ) {
-      synthesis = {
-        ...synthesis,
-        llmError: 'LLM synthesis is not configured, so the deterministic summary is shown.',
-      };
-    } else {
-      try {
-        const llmSynthesis = await buildLlmSynthesis(writtenResponses);
-        if (llmSynthesis) {
-          synthesis = llmSynthesis;
-        }
-      } catch (error) {
-        console.error('Error generating LLM synthesis:', error);
-        synthesis = {
-          ...synthesis,
-          llmError: 'LLM synthesis was unavailable, so the deterministic summary is shown.',
-        };
-      }
-    }
-  }
-
-  return buildSummary(discussion, questions, synthesis);
+  return buildSummary(discussion, questions);
 }
 
 app.get('/api/discussions/:topic/summary', async (req, res) => {
   try {
-    const summary = await getDiscussionSummary(req.params.topic, {
-      llm: req.query.synthesis === 'llm',
-    });
+    const summary = await getDiscussionSummary(req.params.topic);
 
     if (!summary) {
       return res.status(404).json({ error: 'Discussion not found' });


### PR DESCRIPTION
## What

Removes the **Generate Synthesis** button and the entire "Written Response Synthesis" feature.

## Why

The button was effectively a no-op. LLM synthesis is gated behind `ENABLE_LLM_SYNTHESIS=true` + `OPENAI_API_KEY`, neither of which is set anywhere in the repo. So clicking **Generate Synthesis** just re-fetched the summary endpoint with `?synthesis=llm` and got back the *same* always-on deterministic summary (plus, at most, a faint "LLM synthesis is not configured" note). With no open-ended/brainstorm responses it changed nothing at all. Rather than wire up the LLM path, we remove the feature.

## Changes

**`client/src/SummaryPage.jsx`**
- Remove the `Generate Synthesis` button, the `SynthesisPanel`/`SynthesisList` components, the `synthesisLoading` state, and the `llm` branch in `loadSummary`.

**`server.js`**
- Remove `buildDeterministicSynthesis`, `buildLlmSynthesis`, `extractResponseText`, the `synthesis` argument to `buildSummary`, the `?synthesis=llm` query handling in the summary route, and the "Written Response Synthesis" section from the final-report HTML.

## Testing

- `npm run build` (client) — passes.
- `npm test` (integration, 35 tests) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)