### PR TITLE
Canonicalize pseudonyms at write time (#57)

### DIFF
--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -1057,7 +1057,10 @@ const DiscussionPage = () => {
 
     const handleVote = (questionId, value) => {
         console.log('Voting:', questionId, value);
-        socket.emit('vote', discussionSlug, questionId, value, userId, displayName);
+        // Send the name mode too: in pseudonym mode the server persists our
+        // reserved handle instead of this possibly-pre-reservation displayName,
+        // closing the submit-before-reservation collision window (#57).
+        socket.emit('vote', discussionSlug, questionId, value, userId, displayName, identity?.mode);
         setSliderValues(prev => ({ ...prev, [questionId]: undefined }));
     };
 
@@ -1105,7 +1108,9 @@ const DiscussionPage = () => {
     };
 
     const handleAddComment = (responseId, body) => {
-        socket.emit('addResponseComment', topic, responseId, body, userId, displayName);
+        // Pass the name mode so pseudonym-mode comments persist under our reserved
+        // handle rather than a pre-reservation local pick (#57); see handleVote.
+        socket.emit('addResponseComment', topic, responseId, body, userId, displayName, identity?.mode);
     };
 
     const handleDeleteComment = (commentId) => {

--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -8,6 +8,7 @@ import {
     setNameMode,
     setCustomName,
     getDisplayName,
+    getEffectiveNameMode,
     ownerToken,
     participantHandle,
     NameModes,
@@ -1059,8 +1060,9 @@ const DiscussionPage = () => {
         console.log('Voting:', questionId, value);
         // Send the name mode too: in pseudonym mode the server persists our
         // reserved handle instead of this possibly-pre-reservation displayName,
-        // closing the submit-before-reservation collision window (#57).
-        socket.emit('vote', discussionSlug, questionId, value, userId, displayName, identity?.mode);
+        // closing the submit-before-reservation collision window (#57). We send the
+        // EFFECTIVE mode so a blank-custom name (shown as the pseudonym) canonicalizes.
+        socket.emit('vote', discussionSlug, questionId, value, userId, displayName, getEffectiveNameMode(identity));
         setSliderValues(prev => ({ ...prev, [questionId]: undefined }));
     };
 
@@ -1110,7 +1112,7 @@ const DiscussionPage = () => {
     const handleAddComment = (responseId, body) => {
         // Pass the name mode so pseudonym-mode comments persist under our reserved
         // handle rather than a pre-reservation local pick (#57); see handleVote.
-        socket.emit('addResponseComment', topic, responseId, body, userId, displayName, identity?.mode);
+        socket.emit('addResponseComment', topic, responseId, body, userId, displayName, getEffectiveNameMode(identity));
     };
 
     const handleDeleteComment = (commentId) => {

--- a/client/src/identity.js
+++ b/client/src/identity.js
@@ -88,6 +88,22 @@ export function getDisplayName(identity, pseudonymOverride) {
     return pseudonym;
 }
 
+// The mode to report to the server on a vote/comment so it can decide whether to
+// canonicalize the handle to the discussion-unique reservation. This is the
+// EFFECTIVE mode, which can differ from identity.mode: a Custom participant who
+// left the name blank is actually shown their pseudonym (getDisplayName falls back
+// to it) and is renamed by the reservation flow like any pseudonym user — so on
+// the wire that's pseudonym mode, not custom. Reporting it as such lets the server
+// store the reserved handle instead of trusting a pre-reservation colliding pick,
+// closing the same submit-before-reservation race for blank-custom users too.
+export function getEffectiveNameMode(identity) {
+    if (!identity) return NameModes.PSEUDONYM;
+    if (identity.mode === NameModes.CUSTOM && !sanitizeCustomName(identity.customName)) {
+        return NameModes.PSEUDONYM;
+    }
+    return identity.mode;
+}
+
 // Fills in defaults for fields older stored identities may not have, so callers
 // can always rely on mode/customName being present.
 function withDefaults(identity) {

--- a/server.js
+++ b/server.js
@@ -2641,23 +2641,51 @@ function* allPseudonyms() {
   }
 }
 
-// Claim `name` for (discussionId, userId): inserts a reservation, or updates this
-// user's existing reservation to the new name (the regenerate path). Returns the
-// reserved name on success, or null when `name` is already held by a DIFFERENT
-// user in this discussion (UNIQUE(discussion_id, pseudonym) violation), so the
-// caller can try the next candidate. This is what makes concurrent joins safe:
-// the database, not a read-then-write in JS, is the arbiter of uniqueness.
-async function reservePseudonym(discussionId, userId, name) {
+// Claim `name` for (discussionId, userId). Returns the reserved name on success,
+// or null when `name` is already held by a DIFFERENT user in this discussion
+// (UNIQUE(discussion_id, pseudonym) violation), so the caller can try the next
+// candidate. The database, not a read-then-write in JS, is the arbiter of
+// uniqueness — that's what makes concurrent joins safe.
+//
+// Two conflict semantics on the (discussion_id, user_id) key:
+//   - overwrite:false (default, initial allocation) — FIRST-WINS. If this user
+//     already has a reservation (e.g. a racing vote and its own requestPseudonym
+//     both allocated), we keep the existing one and return it rather than
+//     replacing it. Replacing would let the loser clobber a handle the winner
+//     already acked to the client (and that the client may have used to rename
+//     its prior responses), splitting the user's name across responses (#58).
+//   - overwrite:true (the regenerate/shuffle button) — the user deliberately
+//     wants a NEW handle, so we update their existing row.
+async function reservePseudonym(discussionId, userId, name, { overwrite = false } = {}) {
   try {
+    if (overwrite) {
+      const result = await pool.query(
+        `INSERT INTO discussion_pseudonyms (discussion_id, user_id, pseudonym)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (discussion_id, user_id)
+         DO UPDATE SET pseudonym = EXCLUDED.pseudonym
+         RETURNING pseudonym`,
+        [discussionId, userId, name]
+      );
+      return result.rows[0] ? result.rows[0].pseudonym : null;
+    }
     const result = await pool.query(
       `INSERT INTO discussion_pseudonyms (discussion_id, user_id, pseudonym)
        VALUES ($1, $2, $3)
-       ON CONFLICT (discussion_id, user_id)
-       DO UPDATE SET pseudonym = EXCLUDED.pseudonym
+       ON CONFLICT (discussion_id, user_id) DO NOTHING
        RETURNING pseudonym`,
       [discussionId, userId, name]
     );
-    return result.rows[0] ? result.rows[0].pseudonym : null;
+    if (result.rows[0]) return result.rows[0].pseudonym; // we inserted — we won
+    // No row returned ⇒ this user already had a reservation (the other racer won).
+    // A name-already-taken-by-someone-else conflict is on the (discussion_id,
+    // pseudonym) constraint instead, which DO NOTHING doesn't catch — it raises
+    // 23505 and is handled below. So re-read and return the winning handle.
+    const existing = await pool.query(
+      'SELECT pseudonym FROM discussion_pseudonyms WHERE discussion_id = $1 AND user_id = $2',
+      [discussionId, userId]
+    );
+    return existing.rows[0] ? existing.rows[0].pseudonym : null;
   } catch (e) {
     if (e.code === '23505') return null; // name taken by someone else; try the next
     throw e;
@@ -2739,7 +2767,7 @@ async function assignPseudonym(slug, userId, preferred, { regenerate = false } =
   }
 
   for (const name of candidates) {
-    const reserved = await reservePseudonym(discussionId, userId, name);
+    const reserved = await reservePseudonym(discussionId, userId, name, { overwrite: regenerate });
     if (reserved) return { pseudonym: reserved, reserved: true };
   }
 
@@ -2754,7 +2782,7 @@ async function assignPseudonym(slug, userId, preferred, { regenerate = false } =
     // the same taken string every iteration and looping forever without acking.
     const suffix = ` ${n}`;
     const name = `${base.slice(0, MAX_PSEUDONYM_LENGTH - suffix.length)}${suffix}`;
-    const reserved = await reservePseudonym(discussionId, userId, name);
+    const reserved = await reservePseudonym(discussionId, userId, name, { overwrite: regenerate });
     if (reserved) return { pseudonym: reserved, reserved: true };
   }
 }

--- a/server.js
+++ b/server.js
@@ -839,7 +839,7 @@ io.on('connection', (socket) => {
       }
       // Persist the reserved handle in pseudonym mode rather than the client's
       // (possibly pre-reservation, colliding) local pick — see canonicalPseudonym.
-      const handle = await canonicalPseudonym(target.discussionId, userId, mode, pseudonym);
+      const handle = await canonicalPseudonym(discussionSlug, target.discussionId, userId, mode, pseudonym);
       await addVote(questionId, vote, userId, handle);
       const questions = await getQuestions(discussionSlug);
       io.to(discussionSlug).emit('questions', questions);
@@ -1226,7 +1226,7 @@ io.on('connection', (socket) => {
       // (possibly pre-reservation, colliding) local pick — see canonicalPseudonym.
       // Custom/Anonymous stay as sent. canonicalPseudonym also sanitizes (trim +
       // length cap) so a crafted oversized/whitespace name can't break the UI.
-      const handle = await canonicalPseudonym(ctx.discussionId, userId, mode, pseudonym);
+      const handle = await canonicalPseudonym(discussionSlug, ctx.discussionId, userId, mode, pseudonym);
       await pool.query(
         'INSERT INTO response_comments (response_id, user_id, pseudonym, body) VALUES ($1, $2, $3, $4)',
         [responseId, userId, handle, text.slice(0, 2000)]
@@ -2573,22 +2573,32 @@ const NAME_MODE_PSEUDONYM = 'pseudonym';
 // client sent, closing the submit-before-reservation race (#57): on joining an
 // existing discussion there's a brief window where the client falls back to its
 // unreserved local pick, and if that pick collides with a handle already taken in
-// the discussion the row would otherwise persist a visible duplicate. Looking up
-// the reservation at write time fixes that deterministically whenever a
-// reservation exists — and by the time the colliding reconciliation could run, one
-// always does. Custom names and "Anonymous" are stored as-is (only sanitized).
-// `mode` is undefined for pre-#57 clients; those keep the old store-as-sent
-// behavior. We also fall back to the client's value when no reservation exists
-// yet (e.g. the discussion row hasn't been created) — that's what the client is
-// already showing locally, and the existing updateDisplayName path reconciles it.
-async function canonicalPseudonym(discussionId, userId, mode, clientPseudonym) {
+// the discussion the row would otherwise persist a visible duplicate.
+//
+// The common case is a cheap lookup: the join-time reservation already exists, so
+// we store it. The hard case is the actual race — the vote/comment beat the
+// requestPseudonym round-trip, so no row exists yet. We must NOT fall back to the
+// client value here: that value may be the colliding pick, and the client's later
+// updateDisplayName reconciliation can interleave BEFORE this insert lands (socket
+// handlers aren't awaited in order), leaving exactly the duplicate this is meant to
+// prevent. Instead we create-and-await the reservation now via assignPseudonym,
+// which serializes with the in-flight requestPseudonym through the
+// discussion_pseudonyms unique constraint — whichever path inserts first wins and
+// the other returns the same row — so a unique handle is stored deterministically.
+//
+// Custom names and "Anonymous" are stored as-is (only sanitized). `mode` is
+// undefined for pre-#57 clients; those keep the old store-as-sent behavior.
+async function canonicalPseudonym(slug, discussionId, userId, mode, clientPseudonym) {
   const sanitized = sanitizePseudonym(clientPseudonym);
   if (mode !== NAME_MODE_PSEUDONYM || !discussionId || !userId) return sanitized;
-  const result = await pool.query(
+  const existing = await pool.query(
     'SELECT pseudonym FROM discussion_pseudonyms WHERE discussion_id = $1 AND user_id = $2',
     [discussionId, userId]
   );
-  return result.rows[0] ? result.rows[0].pseudonym : sanitized;
+  if (existing.rows[0]) return existing.rows[0].pseudonym;
+  // No reservation yet — create one now rather than trusting the client's pick.
+  const { pseudonym } = await assignPseudonym(slug, userId, clientPseudonym);
+  return pseudonym || sanitized;
 }
 
 // Pool of friendly handles. MUST stay in sync with the ADJECTIVES/ANIMALS lists

--- a/server.js
+++ b/server.js
@@ -822,7 +822,7 @@ io.on('connection', (socket) => {
     }
   });
 
-  socket.on('vote', async (topic, questionId, vote, userId, pseudonym) => {
+  socket.on('vote', async (topic, questionId, vote, userId, pseudonym, mode) => {
     const discussionSlug = slugifyTopic(topic);
     try {
       // Verify the question actually belongs to this topic AND that the topic is
@@ -837,7 +837,10 @@ io.on('connection', (socket) => {
         socket.emit('error', { message: 'Voting is closed for this discussion.' });
         return;
       }
-      await addVote(questionId, vote, userId, pseudonym);
+      // Persist the reserved handle in pseudonym mode rather than the client's
+      // (possibly pre-reservation, colliding) local pick — see canonicalPseudonym.
+      const handle = await canonicalPseudonym(target.discussionId, userId, mode, pseudonym);
+      await addVote(questionId, vote, userId, handle);
       const questions = await getQuestions(discussionSlug);
       io.to(discussionSlug).emit('questions', questions);
     } catch (error) {
@@ -1197,7 +1200,14 @@ io.on('connection', (socket) => {
     }
   });
 
-  socket.on('addResponseComment', async (topic, responseId, body, userId, pseudonym, ack) => {
+  socket.on('addResponseComment', async (topic, responseId, body, userId, pseudonym, mode, ack) => {
+    // Back-compat: pre-#57 clients used (topic, responseId, body, userId,
+    // pseudonym, ack) with no mode, so their ack arrives bound to `mode`. Detect
+    // that and shift it back, leaving mode undefined (store-as-sent behavior).
+    if (typeof mode === 'function' && ack === undefined) {
+      ack = mode;
+      mode = undefined;
+    }
     const discussionSlug = slugifyTopic(topic);
     const reply = (result) => { if (typeof ack === 'function') ack(result); };
     try {
@@ -1212,11 +1222,14 @@ io.on('connection', (socket) => {
         reply({ added: false });
         return;
       }
-      // Sanitize the display name the same way votes do (trim + length cap), so
-      // a crafted oversized/whitespace pseudonym can't bloat or break the UI.
+      // Persist the reserved handle in pseudonym mode rather than the client's
+      // (possibly pre-reservation, colliding) local pick — see canonicalPseudonym.
+      // Custom/Anonymous stay as sent. canonicalPseudonym also sanitizes (trim +
+      // length cap) so a crafted oversized/whitespace name can't break the UI.
+      const handle = await canonicalPseudonym(ctx.discussionId, userId, mode, pseudonym);
       await pool.query(
         'INSERT INTO response_comments (response_id, user_id, pseudonym, body) VALUES ($1, $2, $3, $4)',
-        [responseId, userId, sanitizePseudonym(pseudonym), text.slice(0, 2000)]
+        [responseId, userId, handle, text.slice(0, 2000)]
       );
       io.to(discussionSlug).emit('questions', await getQuestions(discussionSlug));
       reply({ added: true });
@@ -2502,14 +2515,18 @@ async function isModeratorOnlyQuestions(topic) {
 async function getQuestionForTopic(topic, questionId) {
   const slug = slugifyTopic(topic);
   const result = await pool.query(
-    `SELECT q.id, d.locked
+    `SELECT q.id, q.discussion_id, d.locked
      FROM questions q
      JOIN discussions d ON q.discussion_id = d.id
      WHERE d.slug = $1 AND q.id = $2`,
     [slug, questionId]
   );
   if (result.rows.length === 0) return null;
-  return { id: result.rows[0].id, locked: result.rows[0].locked === true };
+  return {
+    id: result.rows[0].id,
+    discussionId: result.rows[0].discussion_id,
+    locked: result.rows[0].locked === true,
+  };
 }
 
 // Return the text of the most similar existing statement in the discussion if
@@ -2544,6 +2561,34 @@ function sanitizePseudonym(pseudonym) {
   if (typeof pseudonym !== 'string') return null;
   const trimmed = pseudonym.trim().slice(0, MAX_PSEUDONYM_LENGTH);
   return trimmed || null;
+}
+
+// The one name mode the server arbitrates. MUST match NameModes.PSEUDONYM in
+// client/src/identity.js. The other modes ('custom', 'anonymous') are deliberate
+// user choices the server stores verbatim, so only this one needs a constant.
+const NAME_MODE_PSEUDONYM = 'pseudonym';
+
+// Resolve the display name to actually persist on a vote/comment. For pseudonym
+// mode we trust the RESERVED handle in discussion_pseudonyms over the name the
+// client sent, closing the submit-before-reservation race (#57): on joining an
+// existing discussion there's a brief window where the client falls back to its
+// unreserved local pick, and if that pick collides with a handle already taken in
+// the discussion the row would otherwise persist a visible duplicate. Looking up
+// the reservation at write time fixes that deterministically whenever a
+// reservation exists — and by the time the colliding reconciliation could run, one
+// always does. Custom names and "Anonymous" are stored as-is (only sanitized).
+// `mode` is undefined for pre-#57 clients; those keep the old store-as-sent
+// behavior. We also fall back to the client's value when no reservation exists
+// yet (e.g. the discussion row hasn't been created) — that's what the client is
+// already showing locally, and the existing updateDisplayName path reconciles it.
+async function canonicalPseudonym(discussionId, userId, mode, clientPseudonym) {
+  const sanitized = sanitizePseudonym(clientPseudonym);
+  if (mode !== NAME_MODE_PSEUDONYM || !discussionId || !userId) return sanitized;
+  const result = await pool.query(
+    'SELECT pseudonym FROM discussion_pseudonyms WHERE discussion_id = $1 AND user_id = $2',
+    [discussionId, userId]
+  );
+  return result.rows[0] ? result.rows[0].pseudonym : sanitized;
 }
 
 // Pool of friendly handles. MUST stay in sync with the ADJECTIVES/ANIMALS lists
@@ -2823,7 +2868,7 @@ async function toggleResponseVote(topic, responseId, userId) {
 async function getResponseContext(topic, responseId) {
   const slug = slugifyTopic(topic);
   const result = await pool.query(
-    `SELECT v.user_id, q.type, d.reactions_enabled, d.reactions_visible, d.comments_enabled, d.locked, d.reaction_keys
+    `SELECT v.user_id, q.discussion_id, q.type, d.reactions_enabled, d.reactions_visible, d.comments_enabled, d.locked, d.reaction_keys
      FROM votes v
      JOIN questions q ON v.question_id = q.id
      JOIN discussions d ON q.discussion_id = d.id
@@ -2834,6 +2879,7 @@ async function getResponseContext(topic, responseId) {
   const row = result.rows[0];
   return {
     ownerId: row.user_id,
+    discussionId: row.discussion_id,
     type: row.type,
     reactionsEnabled: row.reactions_enabled === true,
     reactionsVisible: row.reactions_visible === true,

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -1891,6 +1891,42 @@ test('A pseudonym-mode vote with NO prior reservation still gets a unique handle
   }
 });
 
+test('Concurrent reservations for the same user converge to one handle, not an overwrite (#58)', async () => {
+  const topic = uniqueTopic('pseudonym-converge');
+  const holder = await connectSocket();
+  const tabA = await connectSocket();
+  const tabB = await connectSocket();
+  try {
+    holder.emit('joinDiscussion', topic);
+    tabA.emit('joinDiscussion', topic);
+    tabB.emit('joinDiscussion', topic);
+    await addBrainstormQuestion(holder, topic, 'Ideas?');
+
+    // "Tidy Newt" is taken, so the same new user gets deconflicted either way —
+    // forcing the allocation path, not the cheap "already reserved" early return.
+    await emitWithAck(holder, 'requestPseudonym', topic, 'user-holder', 'Tidy Newt');
+
+    // Two tabs of the SAME user race their reservation at once (the vote/comment
+    // write path and requestPseudonym hit this same allocator). First-wins must
+    // make them agree; the old DO UPDATE could let the second overwrite the first,
+    // splitting the handle across the user's responses.
+    const [ra, rb] = await Promise.all([
+      emitWithAck(tabA, 'requestPseudonym', topic, 'race-user', 'Tidy Newt'),
+      emitWithAck(tabB, 'requestPseudonym', topic, 'race-user', 'Tidy Newt'),
+    ]);
+    assert.notEqual(ra.pseudonym, 'Tidy Newt');
+    assert.equal(ra.pseudonym, rb.pseudonym, 'both tabs must converge on one handle');
+
+    const rows = await pool.query(
+      "SELECT COUNT(*)::int AS n FROM discussion_pseudonyms WHERE user_id = 'race-user'");
+    assert.equal(rows.rows[0].n, 1, 'exactly one reservation row for the user');
+  } finally {
+    holder.disconnect();
+    tabA.disconnect();
+    tabB.disconnect();
+  }
+});
+
 test('A pseudonym-mode comment sent before the reservation ack persists under the reserved handle (#57)', async () => {
   const topic = uniqueTopic('pseudonym-canon-comment');
   const mod = await connectSocket();

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -1854,15 +1854,58 @@ test('A pseudonym-mode vote sent before the reservation ack persists under the r
   }
 });
 
+test('A pseudonym-mode vote with NO prior reservation still gets a unique handle, not the colliding pick (#57)', async () => {
+  const topic = uniqueTopic('pseudonym-canon-noreserve');
+  const holder = await connectSocket();
+  const latecomer = await connectSocket();
+  try {
+    holder.emit('joinDiscussion', topic);
+    latecomer.emit('joinDiscussion', topic);
+    const question = await addBrainstormQuestion(holder, topic, 'Ideas?');
+
+    // "Tidy Newt" is taken in this discussion.
+    const taken = await emitWithAck(holder, 'requestPseudonym', topic, 'user-holder', 'Tidy Newt');
+    assert.equal(taken.pseudonym, 'Tidy Newt');
+
+    // The harder race (Codex P2 on #58): the latecomer's vote BEATS its own
+    // requestPseudonym round-trip, so no reservation row exists for them yet — and
+    // it sends the colliding local pick. The server must create/await a reservation
+    // at write time rather than fall back to storing "Tidy Newt".
+    const ideaUpdate = waitForQuestions(holder, (qs) => {
+      const q = qs.find((x) => x.id === question.id);
+      return q && q.votes.length === 1;
+    }, 'latecomer idea');
+    latecomer.emit('vote', topic, question.id, 'My idea', 'user-late', 'Tidy Newt', 'pseudonym');
+    const stored = (await ideaUpdate).find((x) => x.id === question.id).votes[0];
+
+    assert.notEqual(stored.pseudonym, 'Tidy Newt', 'must not store the colliding handle');
+    assert.ok(stored.pseudonym, 'a deconflicted handle should be stored');
+
+    // The created reservation is now the stable handle for this user, so a later
+    // requestPseudonym returns the SAME name the vote was stored under (no rename).
+    const reserved = await emitWithAck(latecomer, 'requestPseudonym', topic, 'user-late', 'Tidy Newt');
+    assert.equal(reserved.pseudonym, stored.pseudonym, 'write-path reservation should be stable');
+  } finally {
+    holder.disconnect();
+    latecomer.disconnect();
+  }
+});
+
 test('A pseudonym-mode comment sent before the reservation ack persists under the reserved handle (#57)', async () => {
   const topic = uniqueTopic('pseudonym-canon-comment');
   const mod = await connectSocket();
+  const holder = await connectSocket();
   const latecomer = await connectSocket();
   try {
     mod.emit('joinDiscussion', topic);
+    holder.emit('joinDiscussion', topic);
     latecomer.emit('joinDiscussion', topic);
     const token = await claimModerator(mod, topic);
     const question = await addBrainstormQuestion(mod, topic, 'What should we try?');
+
+    // A dedicated participant occupies "Tidy Newt" so it's taken in this discussion.
+    const taken = await emitWithAck(holder, 'requestPseudonym', topic, 'user-holder', 'Tidy Newt');
+    assert.equal(taken.pseudonym, 'Tidy Newt');
 
     // An idea for the latecomer to comment on.
     const ideaUpdate = waitForQuestions(mod, (qs) => qs[0] && qs[0].votes.length === 1, 'idea added');
@@ -1874,7 +1917,6 @@ test('A pseudonym-mode comment sent before the reservation ack persists under th
     await enabled;
 
     // "Tidy Newt" is taken, so the latecomer is reserved a different handle.
-    await emitWithAck(mod, 'requestPseudonym', topic, 'user-mod', 'Tidy Newt');
     const reserved = await emitWithAck(latecomer, 'requestPseudonym', topic, 'user-late', 'Tidy Newt');
     assert.notEqual(reserved.pseudonym, 'Tidy Newt');
 
@@ -1893,6 +1935,7 @@ test('A pseudonym-mode comment sent before the reservation ack persists under th
     assert.notEqual(comment.pseudonym, 'Tidy Newt', 'no duplicate "Tidy Newt" should be stored');
   } finally {
     mod.disconnect();
+    holder.disconnect();
     latecomer.disconnect();
   }
 });

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -1816,6 +1816,116 @@ test('A newcomer avoids a handle already shown on a pre-existing response', asyn
   }
 });
 
+test('A pseudonym-mode vote sent before the reservation ack persists under the reserved handle (#57)', async () => {
+  const topic = uniqueTopic('pseudonym-canon-vote');
+  const holder = await connectSocket();
+  const latecomer = await connectSocket();
+  try {
+    holder.emit('joinDiscussion', topic);
+    latecomer.emit('joinDiscussion', topic);
+    // Adding a question creates the discussion row so handles can be reserved.
+    const question = await addBrainstormQuestion(holder, topic, 'Ideas?');
+
+    // "Tidy Newt" is already taken in this discussion.
+    const taken = await emitWithAck(holder, 'requestPseudonym', topic, 'user-holder', 'Tidy Newt');
+    assert.equal(taken.pseudonym, 'Tidy Newt');
+
+    // The latecomer's local pick collides, so the server reserves a DIFFERENT
+    // handle. That reservation exists server-side while the client is still — for
+    // the round-trip window — showing and sending its unreserved local pick.
+    const reserved = await emitWithAck(latecomer, 'requestPseudonym', topic, 'user-late', 'Tidy Newt');
+    assert.notEqual(reserved.pseudonym, 'Tidy Newt');
+
+    // Simulate the race: the latecomer votes in pseudonym mode but still sends the
+    // colliding pre-reservation name. The server must store the reserved handle so
+    // no duplicate "Tidy Newt" ever appears.
+    const ideaUpdate = waitForQuestions(holder, (qs) => {
+      const q = qs.find((x) => x.id === question.id);
+      return q && q.votes.length === 1;
+    }, 'latecomer idea');
+    latecomer.emit('vote', topic, question.id, 'My idea', 'user-late', 'Tidy Newt', 'pseudonym');
+    const stored = (await ideaUpdate).find((x) => x.id === question.id).votes[0];
+
+    assert.equal(stored.pseudonym, reserved.pseudonym, 'vote should persist under the reserved handle');
+    assert.notEqual(stored.pseudonym, 'Tidy Newt', 'no duplicate "Tidy Newt" should be stored');
+  } finally {
+    holder.disconnect();
+    latecomer.disconnect();
+  }
+});
+
+test('A pseudonym-mode comment sent before the reservation ack persists under the reserved handle (#57)', async () => {
+  const topic = uniqueTopic('pseudonym-canon-comment');
+  const mod = await connectSocket();
+  const latecomer = await connectSocket();
+  try {
+    mod.emit('joinDiscussion', topic);
+    latecomer.emit('joinDiscussion', topic);
+    const token = await claimModerator(mod, topic);
+    const question = await addBrainstormQuestion(mod, topic, 'What should we try?');
+
+    // An idea for the latecomer to comment on.
+    const ideaUpdate = waitForQuestions(mod, (qs) => qs[0] && qs[0].votes.length === 1, 'idea added');
+    mod.emit('vote', topic, question.id, 'Run a pilot', 'user-mod', 'Planner', 'pseudonym');
+    const responseId = (await ideaUpdate)[0].votes[0].id;
+
+    const enabled = waitForQuestions(mod, (qs) => qs[0] && qs[0].commentsEnabled === true, 'comments enabled');
+    mod.emit('setDiscussionFlags', topic, { comments_enabled: true }, token);
+    await enabled;
+
+    // "Tidy Newt" is taken, so the latecomer is reserved a different handle.
+    await emitWithAck(mod, 'requestPseudonym', topic, 'user-mod', 'Tidy Newt');
+    const reserved = await emitWithAck(latecomer, 'requestPseudonym', topic, 'user-late', 'Tidy Newt');
+    assert.notEqual(reserved.pseudonym, 'Tidy Newt');
+
+    // Race: comment in pseudonym mode but still sending the colliding local pick.
+    const commentUpdate = waitForQuestions(
+      mod,
+      (qs) => qs[0] && qs[0].votes[0] && (qs[0].votes[0].comments || []).length === 1,
+      'comment added'
+    );
+    const ack = await emitWithAck(
+      latecomer, 'addResponseComment', topic, responseId, 'A point', 'user-late', 'Tidy Newt', 'pseudonym');
+    assert.equal(ack.added, true);
+    const comment = (await commentUpdate)[0].votes[0].comments[0];
+
+    assert.equal(comment.pseudonym, reserved.pseudonym, 'comment should persist under the reserved handle');
+    assert.notEqual(comment.pseudonym, 'Tidy Newt', 'no duplicate "Tidy Newt" should be stored');
+  } finally {
+    mod.disconnect();
+    latecomer.disconnect();
+  }
+});
+
+test('Custom names are stored verbatim, never replaced by the reserved handle (#57)', async () => {
+  const topic = uniqueTopic('pseudonym-canon-custom');
+  const mod = await connectSocket();
+  const user = await connectSocket();
+  try {
+    mod.emit('joinDiscussion', topic);
+    user.emit('joinDiscussion', topic);
+    const question = await addBrainstormQuestion(mod, topic, 'Ideas?');
+
+    // The user holds a reserved pseudonym in this discussion...
+    const reserved = await emitWithAck(user, 'requestPseudonym', topic, 'user-1', 'Tidy Newt');
+    assert.equal(reserved.pseudonym, 'Tidy Newt');
+
+    // ...but submits in CUSTOM mode: their typed name must be stored as-is, never
+    // canonicalized to the reserved handle (custom is a deliberate user choice).
+    const customUpdate = waitForQuestions(mod, (qs) => {
+      const q = qs.find((x) => x.id === question.id);
+      return q && q.votes.length === 1;
+    }, 'custom-mode idea');
+    user.emit('vote', topic, question.id, 'My idea', 'user-1', 'Dr. Real Name', 'custom');
+    const stored = (await customUpdate).find((x) => x.id === question.id).votes[0];
+
+    assert.equal(stored.pseudonym, 'Dr. Real Name');
+  } finally {
+    mod.disconnect();
+    user.disconnect();
+  }
+});
+
 test('a moderator can edit a question before anyone responds', async () => {
   const topic = uniqueTopic('edit-question');
   const mod = await connectSocket();


### PR DESCRIPTION
Closes #57.

## What & why

Follow-up to #45. On joining an **existing** discussion there's a brief window (the `requestPseudonym` reservation round-trip) where the client falls back to its **unreserved** local pseudonym. If a participant submits a vote/comment in that window **and** their local pick collides with a handle already taken in the discussion, the row could persist under the colliding handle — a visible duplicate label despite the reservation table. Worst case is cosmetic (no data loss / security / broken voting), raised as P2 by Codex on #45 and deferred there.

## How

- Thread the name **mode** (`pseudonym` / `custom` / `anonymous`) onto the `vote` and `addResponseComment` socket events (`identity?.mode` from the client).
- New server helper `canonicalPseudonym(discussionId, userId, mode, clientPseudonym)`: in **pseudonym** mode it persists the **reserved** handle from `discussion_pseudonyms` (looked up at write time) instead of trusting the client-sent name. **Custom** and **"Anonymous"** are stored as-is (sanitized).
- This closes the window deterministically whenever a reservation exists — and by the time the colliding `updateDisplayName` reconciliation could run, one always does. If no reservation exists yet (discussion not created), it falls back to the client value, which the existing `updateDisplayName` path still reconciles.
- `getQuestionForTopic` / `getResponseContext` now also return `discussionId` (reusing queries they already run — no extra round-trips on the hot path beyond the one reservation lookup, and only in pseudonym mode).

### Back-compat
- A **missing** `mode` (pre-deploy clients) keeps the old store-as-sent behavior.
- `addResponseComment`'s new `(…, pseudonym, mode, ack)` arity detects the old `(…, pseudonym, ack)` shape (ack arrived in the `mode` slot) and shifts it back, so existing callers' ack callbacks still fire — same pattern `addQuestion` already uses.

## Tests
3 new integration tests:
- pseudonym-mode **vote** submitted before the reservation ack persists under the reserved handle (no duplicate `Tidy Newt`),
- same for a **comment**,
- **custom** names are stored verbatim, never replaced by the reserved handle.

**53 tests pass** (`npm test`); **client build passes** (`npm run build`).

## Acceptance (from #57)
- [x] A pseudonym-mode vote/comment submitted before the reservation ack persists under the user's reserved handle.
- [x] Custom names and "Anonymous" are unaffected.
- [x] Integration test simulating submit-before-reservation + collision shows no duplicate handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Votes and comments consistently record the reserved pseudonym to avoid duplicate/colliding display names and preserve correct attribution.
  * Custom display names are preserved; empty/trimmed custom names now fall back to pseudonym behavior.
  * Improved consistency across tabs and concurrent actions so reservations converge to a single stable handle.

* **Tests**
  * Added integration tests for pseudonym reservation races, deconfliction, and mode-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->