### PR TITLE
Fix: Yes/No questions can't be edited (missing from edit-validation set)

### DIFF
--- a/server.js
+++ b/server.js
@@ -1676,7 +1676,7 @@ function resolveReactionKeys(raw) {
 
 // The question types a discussion supports. Mirrors QuestionTypes in
 // client/src/DiscussionPage.jsx — used to validate edits server-side.
-const VALID_QUESTION_TYPES = new Set(['Agreement', 'Numerical', 'Open Ended', 'Brainstorm']);
+const VALID_QUESTION_TYPES = new Set(['Agreement', 'Yes/No', 'Numerical', 'Open Ended', 'Brainstorm']);
 
 // Enrich Brainstorm responses in place with aggregated interaction data:
 // quality up/down tallies, the agreement distribution, reaction counts, and

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -1844,6 +1844,41 @@ test('a moderator can edit a question before anyone responds', async () => {
   }
 });
 
+test('a moderator can edit a question to and from the Yes/No type', async () => {
+  const topic = uniqueTopic('edit-yesno');
+  const mod = await connectSocket();
+
+  try {
+    mod.emit('joinDiscussion', topic);
+    const token = await claimModerator(mod, topic);
+
+    const added = waitForQuestions(mod, (qs) => qs.some((q) => q.text === 'Agree?'), 'question added');
+    mod.emit('addQuestion', topic, { text: 'Agree?', type: 'Agreement', minValue: null, maxValue: null, options: [] });
+    const question = (await added).find((q) => q.text === 'Agree?');
+
+    // Switching an unanswered question to Yes/No must be accepted (Yes/No is a
+    // valid type, so the server-side edit validation has to allow it).
+    const toYesNo = waitForQuestions(mod, (qs) => qs[0] && qs[0].type === 'Yes/No', 'edit to Yes/No');
+    const ack = await emitWithAck(mod, 'editQuestion', topic, question.id,
+      { text: 'Yes or no?', type: 'Yes/No' }, token);
+    assert.equal(ack.updated, true);
+
+    const edited = (await toYesNo)[0];
+    assert.equal(edited.text, 'Yes or no?');
+    assert.equal(edited.type, 'Yes/No');
+
+    // Editing an existing Yes/No question (its form always re-submits type:
+    // 'Yes/No') must likewise succeed rather than be rejected as invalid.
+    const reword = waitForQuestions(mod, (qs) => qs[0] && qs[0].text === 'Yes or no, really?', 'reword broadcast');
+    const ack2 = await emitWithAck(mod, 'editQuestion', topic, question.id,
+      { text: 'Yes or no, really?', type: 'Yes/No' }, token);
+    assert.equal(ack2.updated, true);
+    assert.equal((await reword)[0].type, 'Yes/No');
+  } finally {
+    mod.disconnect();
+  }
+});
+
 test('editing a question is refused once it has responses', async () => {
   const topic = uniqueTopic('edit-locked');
   const mod = await connectSocket();


### PR DESCRIPTION
## What

`VALID_QUESTION_TYPES` (the set the `editQuestion` handler uses to validate edits) was missing `'Yes/No'`.

This is a **merge collision between two recently-merged PRs**: #43 ("edit questions before the first response") introduced the validation set, and #49 ("Yes/No question type", merged after) added the type everywhere *except* here. The comment on the set even claims it "Mirrors QuestionTypes in client/src/DiscussionPage.jsx" — but it no longer did.

## Impact (user-facing)

The edit form always submits the question's `type`, and lists Yes/No as an option, so:

- Switching any unanswered question **to** Yes/No → rejected with "Failed to save changes."
- An unanswered **Yes/No question could not be edited at all** — even a pure text fix re-submits `type: 'Yes/No'` and was rejected as invalid.

## Fix

- Add `'Yes/No'` to `VALID_QUESTION_TYPES` (one line).
- Regression test covering both directions: editing a question *to* Yes/No, and rewording an existing Yes/No question.

## Tests

`npm test` (integration suite, Dockerized Postgres) — **51/51 passing**, including the new `a moderator can edit a question to and from the Yes/No type`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)