### PR TITLE
Fix: validate single-choice vote values; harden clustering prototype-key guard

### DIFF
--- a/clustering.js
+++ b/clustering.js
@@ -71,7 +71,11 @@ function buildVoteMatrix(questions) {
   const votedStatementIds = new Set();
   agreementQuestions.forEach(q => {
     (q.votes || []).forEach(v => {
-      if (!v.userId || !(v.value in AGREEMENT_SCORES)) {
+      // Use hasOwnProperty, not `in`: `in` also matches inherited Object
+      // prototype keys, so a crafted vote value like "constructor" or
+      // "toString" would pass the guard and pull a function off the prototype
+      // into the matrix, poisoning the clustering math with NaN.
+      if (!v.userId || !Object.prototype.hasOwnProperty.call(AGREEMENT_SCORES, v.value)) {
         return;
       }
       if (!byUser.has(v.userId)) {

--- a/server.js
+++ b/server.js
@@ -837,6 +837,18 @@ io.on('connection', (socket) => {
         socket.emit('error', { message: 'Voting is closed for this discussion.' });
         return;
       }
+      // Single-choice opinion types only accept their known options. Without
+      // this, a crafted socket message could store an arbitrary string as an
+      // Agreement/Yes-No vote, skewing the results bars and the cluster
+      // analysis (which scores votes by their agreement label).
+      if (target.type === 'Agreement' && !AGREEMENT_OPTIONS.includes(vote)) {
+        socket.emit('error', { message: 'Invalid vote.' });
+        return;
+      }
+      if (target.type === 'Yes/No' && !YES_NO_OPTIONS.includes(vote)) {
+        socket.emit('error', { message: 'Invalid vote.' });
+        return;
+      }
       await addVote(questionId, vote, userId, pseudonym);
       const questions = await getQuestions(discussionSlug);
       io.to(discussionSlug).emit('questions', questions);
@@ -2502,14 +2514,14 @@ async function isModeratorOnlyQuestions(topic) {
 async function getQuestionForTopic(topic, questionId) {
   const slug = slugifyTopic(topic);
   const result = await pool.query(
-    `SELECT q.id, d.locked
+    `SELECT q.id, q.type, d.locked
      FROM questions q
      JOIN discussions d ON q.discussion_id = d.id
      WHERE d.slug = $1 AND q.id = $2`,
     [slug, questionId]
   );
   if (result.rows.length === 0) return null;
-  return { id: result.rows[0].id, locked: result.rows[0].locked === true };
+  return { id: result.rows[0].id, type: result.rows[0].type, locked: result.rows[0].locked === true };
 }
 
 // Return the text of the most similar existing statement in the discussion if

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -285,6 +285,42 @@ test('Yes/No questions record a single choice that toggles off when reselected',
   }
 });
 
+test('a crafted Agreement/Yes-No vote with an unknown value is rejected, not stored', async () => {
+  const topic = uniqueTopic('vote-validation');
+  const author = await connectSocket();
+  const voter = await connectSocket();
+
+  try {
+    author.emit('joinDiscussion', topic);
+    voter.emit('joinDiscussion', topic);
+
+    const agreeAdded = waitForQuestions(author, (qs) => qs.some((q) => q.text === 'Agree?'), 'agreement added');
+    author.emit('addQuestion', topic, { text: 'Agree?', type: 'Agreement', minValue: null, maxValue: null, options: [] });
+    const agree = (await agreeAdded).find((q) => q.text === 'Agree?');
+
+    const ynAdded = waitForQuestions(author, (qs) => qs.some((q) => q.text === 'Ship?'), 'yes/no added');
+    author.emit('addQuestion', topic, { text: 'Ship?', type: 'Yes/No', minValue: null, maxValue: null, options: [] });
+    const yn = (await ynAdded).find((q) => q.text === 'Ship?');
+
+    // "constructor" is an Object.prototype key — the kind of value that used to
+    // slip through clustering's `in` check and corrupt the analysis.
+    const agreeRejected = waitForEvent(voter, 'error', (e) => /invalid vote/i.test(e.message));
+    voter.emit('vote', topic, agree.id, 'constructor', 'attacker', 'Mallory');
+    await agreeRejected;
+
+    const ynRejected = waitForEvent(voter, 'error', (e) => /invalid vote/i.test(e.message));
+    voter.emit('vote', topic, yn.id, 'Maybe', 'attacker', 'Mallory');
+    await ynRejected;
+
+    // Nothing was written for either crafted value.
+    const stored = await pool.query('SELECT COUNT(*)::int AS n FROM votes');
+    assert.equal(stored.rows[0].n, 0);
+  } finally {
+    author.disconnect();
+    voter.disconnect();
+  }
+});
+
 test('Socket.IO sanitizes display names: anonymous stores null, long names are clamped', async () => {
   const topic = uniqueTopic('names');
   const author = await connectSocket();


### PR DESCRIPTION
## What

A crafted socket message could corrupt a discussion's opinion/cluster analysis. Two related gaps:

1. **`addVote` stored vote values with no validation** — a client could persist an arbitrary string as an Agreement / Yes-No vote.
2. **clustering used `value in AGREEMENT_SCORES`** to gate values. The `in` operator also matches inherited `Object.prototype` keys, so a vote value of `"constructor"`, `"toString"`, or `"__proto__"` passed the guard and pulled a *function/object* off the prototype into the participant×statement matrix.

## Impact

The non-numeric value poisons the k-means math with `NaN`: every participant sticks in cluster 0, no `k` split is ever selected, and `analyzeClusters` silently falls into the **k=1 "broad consensus"** path — so a single crafted vote can suppress all real opinion groups and present a false consensus for the whole discussion. Garbage values also skewed the results bars.

It requires a deliberately crafted message (the normal UI never sends bad values); the effect is corrupted analysis, not a crash.

## Fix

- Reject Agreement votes outside `AGREEMENT_OPTIONS` and Yes/No votes outside `YES_NO_OPTIONS` at the write path (`vote` handler). `getQuestionForTopic` now also returns the question `type` (additive).
- Use `Object.prototype.hasOwnProperty.call(AGREEMENT_SCORES, v.value)` instead of `in` in `clustering.js` — defense in depth so the matrix can never pick up a prototype key even if a bad value reaches it some other way.
- Regression test: crafted `"constructor"` (Agreement) and `"Maybe"` (Yes/No) votes are rejected and never stored.

## Tests

`npm test` (integration suite, Dockerized Postgres) — **51/51 passing**, including the new `a crafted Agreement/Yes-No vote with an unknown value is rejected, not stored`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)