### PR TITLE
Bind participant identity to the socket, not to client-supplied userId (#38)

### DIFF
--- a/server.js
+++ b/server.js
@@ -702,6 +702,31 @@ async function emitDiscussionState(topic) {
   io.to(topic).emit('discussionState', await getDiscussionState(topic));
 }
 
+// Resolve the authoritative userId for a socket connection.
+//
+// Identity is a per-CONNECTION property, not a per-message one. We pin it to the
+// socket the first time the client presents its id (via `identify` on connect, or
+// the first ownership action), and from then on every vote / rating / reaction /
+// comment / delete / rename derives ownership from `socket.data.userId` — never
+// from a userId field re-supplied in each individual message. That is what stops
+// a participant from acting as someone else: a socket can only ever be the one
+// identity it first claimed and cannot switch mid-connection, so naming a
+// different id in a later message is ignored rather than honored.
+//
+// This is layered on top of the fact that userId is an unguessable per-browser
+// secret that is never put on the wire (getQuestions replaces it with per-response
+// ownership tokens — see the tokenization there), so a client cannot learn, and
+// therefore cannot claim, an identity that isn't its own in the first place.
+//
+// `claimed` is consulted ONLY to bootstrap an as-yet-unpinned socket; once pinned
+// it is ignored. Returns null if the socket has no identity and none was supplied.
+function bindSocketUser(socket, claimed) {
+  if (!socket.data.userId && claimed) {
+    socket.data.userId = claimed;
+  }
+  return socket.data.userId || null;
+}
+
 // WebSocket handlers
 io.on('connection', (socket) => {
   console.log('New client connected');
@@ -731,18 +756,17 @@ io.on('connection', (socket) => {
     }
   });
 
-  // Associate this socket with the client's persistent userId so the server can
-  // route a live moderator grant to it when a moderator promotes this user.
+  // Pin this socket to the client's persistent userId (see bindSocketUser) so the
+  // server can route a live moderator grant to it when a moderator promotes this
+  // user, and so every ownership action on the connection is attributed correctly.
   //
-  // Deliberately does NOT hand back an existing moderator token here: userId is
-  // not a secret (getQuestions broadcasts each vote's userId to the whole room),
-  // so re-delivering a token to anyone who supplies a promoted user's id would
-  // let an observer steal moderator access. A genuinely promoted user receives
-  // their token live at promotion time and persists it locally (so it survives
-  // reloads/reconnects via verifyAdmin); we never re-mint it from the id alone.
+  // Deliberately does NOT hand back an existing moderator token here: re-delivering
+  // a token to anyone who merely supplies a promoted user's id would let a leaked
+  // id be replayed into moderator access. A genuinely promoted user receives their
+  // token live at promotion time and persists it locally (so it survives reloads /
+  // reconnects via verifyAdmin); we never re-mint it from the id alone.
   socket.on('identify', (topic, userId) => {
-    if (!userId) return;
-    socket.data.userId = userId;
+    bindSocketUser(socket, userId);
   });
 
   socket.on('leaveDiscussion', (topic) => {
@@ -822,8 +846,15 @@ io.on('connection', (socket) => {
     }
   });
 
-  socket.on('vote', async (topic, questionId, vote, userId, pseudonym) => {
+  socket.on('vote', async (topic, questionId, vote, claimedUserId, pseudonym) => {
     const discussionSlug = slugifyTopic(topic);
+    // Attribute the vote to the socket's pinned identity, not to whatever id the
+    // message carries, so a client can't cast votes as another participant.
+    const userId = bindSocketUser(socket, claimedUserId);
+    if (!userId) {
+      socket.emit('error', { message: 'Failed to handle vote' });
+      return;
+    }
     try {
       // Verify the question actually belongs to this topic AND that the topic is
       // not locked. Without this, a client could bypass a locked discussion by
@@ -1158,8 +1189,10 @@ io.on('connection', (socket) => {
     }
   });
 
-  socket.on('toggleResponseVote', async (topic, responseId, userId) => {
+  socket.on('toggleResponseVote', async (topic, responseId, claimedUserId) => {
     const discussionSlug = slugifyTopic(topic);
+    const userId = bindSocketUser(socket, claimedUserId);
+    if (!userId) return;
     try {
       await toggleResponseVote(discussionSlug, responseId, userId);
       const questions = await getQuestions(discussionSlug);
@@ -1173,8 +1206,10 @@ io.on('connection', (socket) => {
   // Set/clear one axis (quality or agreement) of a user's rating on a brainstorm
   // idea. Gated on the question being a Brainstorm with reactions currently
   // revealed, so a hidden/disabled phase can't be rated through a crafted event.
-  socket.on('setResponseRating', async (topic, responseId, axis, value, userId) => {
+  socket.on('setResponseRating', async (topic, responseId, axis, value, claimedUserId) => {
     const discussionSlug = slugifyTopic(topic);
+    const userId = bindSocketUser(socket, claimedUserId);
+    if (!userId) return;
     try {
       if (axis !== 'quality' && axis !== 'agreement') return;
       const ctx = await getResponseContext(topic, responseId);
@@ -1192,8 +1227,10 @@ io.on('connection', (socket) => {
     }
   });
 
-  socket.on('toggleResponseReaction', async (topic, responseId, reaction, userId) => {
+  socket.on('toggleResponseReaction', async (topic, responseId, reaction, claimedUserId) => {
     const discussionSlug = slugifyTopic(topic);
+    const userId = bindSocketUser(socket, claimedUserId);
+    if (!userId) return;
     try {
       const ctx = await getResponseContext(topic, responseId);
       if (!ctx || ctx.locked || ctx.type !== 'Brainstorm' || !ctx.reactionsEnabled || !ctx.reactionsVisible) return;
@@ -1209,9 +1246,14 @@ io.on('connection', (socket) => {
     }
   });
 
-  socket.on('addResponseComment', async (topic, responseId, body, userId, pseudonym, ack) => {
+  socket.on('addResponseComment', async (topic, responseId, body, claimedUserId, pseudonym, ack) => {
     const discussionSlug = slugifyTopic(topic);
     const reply = (result) => { if (typeof ack === 'function') ack(result); };
+    const userId = bindSocketUser(socket, claimedUserId);
+    if (!userId) {
+      reply({ added: false });
+      return;
+    }
     try {
       const ctx = await getResponseContext(topic, responseId);
       // A locked discussion has new statements closed; comments are statements.
@@ -1241,8 +1283,10 @@ io.on('connection', (socket) => {
 
   // Delete a comment. Scoped through the discussion and to the comment's own
   // author, so a participant can only remove their own comments.
-  socket.on('deleteResponseComment', async (topic, commentId, userId) => {
+  socket.on('deleteResponseComment', async (topic, commentId, claimedUserId) => {
     const discussionSlug = slugifyTopic(topic);
+    const userId = bindSocketUser(socket, claimedUserId);
+    if (!userId) return;
     try {
       await pool.query(
         `DELETE FROM response_comments c
@@ -1353,7 +1397,8 @@ io.on('connection', (socket) => {
 
   // Return the requesting user's own ratings/reactions so the client can restore
   // its selected state after a reload or reconnect.
-  socket.on('getBrainstormState', async (topic, userId, ack) => {
+  socket.on('getBrainstormState', async (topic, claimedUserId, ack) => {
+    const userId = bindSocketUser(socket, claimedUserId);
     try {
       const state = await getMyBrainstormState(topic, userId);
       if (typeof ack === 'function') ack(state);
@@ -1363,8 +1408,10 @@ io.on('connection', (socket) => {
     }
   });
 
-  socket.on('deleteVote', async (topic, voteId, userId) => {
+  socket.on('deleteVote', async (topic, voteId, claimedUserId) => {
     const discussionSlug = slugifyTopic(topic);
+    const userId = bindSocketUser(socket, claimedUserId);
+    if (!userId) return;
     try {
       await deleteVote(voteId, userId);
       const questions = await getQuestions(discussionSlug);
@@ -1423,8 +1470,9 @@ io.on('connection', (socket) => {
   // it if free and substitutes a different one if it's already taken, so two
   // people never end up as the same "Tidy Newt". Stable across reloads (a user
   // who already has a reservation gets it back).
-  socket.on('requestPseudonym', async (topic, userId, preferred, cb) => {
+  socket.on('requestPseudonym', async (topic, claimedUserId, preferred, cb) => {
     if (typeof cb !== 'function') return;
+    const userId = bindSocketUser(socket, claimedUserId);
     try {
       if (!topic || !userId) {
         cb({ pseudonym: sanitizePseudonym(preferred), reserved: false });
@@ -1441,8 +1489,9 @@ io.on('connection', (socket) => {
 
   // Shuffle: give this user a brand-new handle, still unique within the
   // discussion and different from their current one.
-  socket.on('regeneratePseudonym', async (topic, userId, cb) => {
+  socket.on('regeneratePseudonym', async (topic, claimedUserId, cb) => {
     if (typeof cb !== 'function') return;
+    const userId = bindSocketUser(socket, claimedUserId);
     try {
       if (!topic || !userId) {
         cb({ pseudonym: null, reserved: false });
@@ -1464,8 +1513,9 @@ io.on('connection', (socket) => {
     }
   });
 
-  socket.on('updateDisplayName', async (topic, userId, displayName) => {
+  socket.on('updateDisplayName', async (topic, claimedUserId, displayName) => {
     const discussionSlug = slugifyTopic(topic);
+    const userId = bindSocketUser(socket, claimedUserId);
     try {
       if (!topic || !userId) return;
       const pseudonym = sanitizePseudonym(displayName);

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -1026,10 +1026,15 @@ test('Brainstorm ratings broadcast as aggregates without exposing who voted', as
   const topic = uniqueTopic('brainstorm-rate');
   const mod = await connectSocket();
   const participant = await connectSocket();
+  // A separate browser does the rating: identity is pinned per socket, so the
+  // idea's author socket can't also stand in as the rater (that would be a
+  // self-rating, which is rejected).
+  const rater = await connectSocket();
 
   try {
     mod.emit('joinDiscussion', topic);
     participant.emit('joinDiscussion', topic);
+    rater.emit('joinDiscussion', topic);
 
     const token = await claimModerator(mod, topic);
 
@@ -1060,7 +1065,7 @@ test('Brainstorm ratings broadcast as aggregates without exposing who voted', as
       (questions) => questions[0] && questions[0].votes[0] && questions[0].votes[0].qualityUp === 1,
       'quality rating broadcast'
     );
-    participant.emit('setResponseRating', topic, responseId, 'quality', 1, 'user-rater');
+    rater.emit('setResponseRating', topic, responseId, 'quality', 1, 'user-rater');
     const rated = (await ratingUpdate)[0].votes[0];
 
     assert.equal(rated.qualityUp, 1);
@@ -1072,15 +1077,22 @@ test('Brainstorm ratings broadcast as aggregates without exposing who voted', as
   } finally {
     mod.disconnect();
     participant.disconnect();
+    rater.disconnect();
   }
 });
 
 test('Brainstorm agreement votes accumulate into a distribution', async () => {
   const topic = uniqueTopic('brainstorm-agree');
   const mod = await connectSocket();
+  // Two separate browsers cast the agreement ratings; the author socket can't
+  // double as a rater (per-socket identity, and self-rating is rejected anyway).
+  const raterA = await connectSocket();
+  const raterB = await connectSocket();
 
   try {
     mod.emit('joinDiscussion', topic);
+    raterA.emit('joinDiscussion', topic);
+    raterB.emit('joinDiscussion', topic);
     const token = await claimModerator(mod, topic);
     const question = await addBrainstormQuestion(mod, topic, 'Pick a direction');
 
@@ -1097,14 +1109,16 @@ test('Brainstorm agreement votes accumulate into a distribution', async () => {
       (qs) => qs[0] && qs[0].votes[0] && (qs[0].votes[0].agreementCounts || {})['Strongly Agree'] === 1,
       'agreement counted'
     );
-    mod.emit('setResponseRating', topic, responseId, 'agreement', 'Strongly Agree', 'user-a');
-    mod.emit('setResponseRating', topic, responseId, 'agreement', 'Disagree', 'user-b');
+    raterA.emit('setResponseRating', topic, responseId, 'agreement', 'Strongly Agree', 'user-a');
+    raterB.emit('setResponseRating', topic, responseId, 'agreement', 'Disagree', 'user-b');
     const counts = (await agreeUpdate)[0].votes[0].agreementCounts;
 
     assert.equal(counts['Strongly Agree'], 1);
     assert.equal(counts['Disagree'], 1);
   } finally {
     mod.disconnect();
+    raterA.disconnect();
+    raterB.disconnect();
   }
 });
 
@@ -1154,6 +1168,84 @@ test('Brainstorm comments can be added, listed with pseudonyms, and deleted', as
   } finally {
     mod.disconnect();
     participant.disconnect();
+  }
+});
+
+test('a participant cannot act as another by supplying their userId (issue #38)', async () => {
+  const topic = uniqueTopic('identity-spoof');
+  const mod = await connectSocket();
+  const victim = await connectSocket();
+  const attacker = await connectSocket();
+
+  try {
+    mod.emit('joinDiscussion', topic);
+    victim.emit('joinDiscussion', topic);
+    attacker.emit('joinDiscussion', topic);
+    // Each socket pins to its own identity up front, exactly as a real client
+    // does on connect. From here on the server attributes every action to the
+    // connection's pinned identity, never to a userId named in the message.
+    victim.emit('identify', topic, 'victim-user');
+    attacker.emit('identify', topic, 'attacker-user');
+
+    const token = await claimModerator(mod, topic);
+    const question = await addBrainstormQuestion(mod, topic, 'Ideas?');
+
+    // The victim posts an idea and a comment on it.
+    const victimIdea = waitForQuestions(mod, (qs) => qs[0] && qs[0].votes.length === 1, 'victim idea');
+    victim.emit('vote', topic, question.id, "victim's idea", 'victim-user', 'Victim');
+    const victimResponseId = (await victimIdea)[0].votes[0].id;
+
+    const commentsOn = waitForQuestions(mod, (qs) => qs[0] && qs[0].commentsEnabled === true, 'comments enabled');
+    mod.emit('setDiscussionFlags', topic, { comments_enabled: true }, token);
+    await commentsOn;
+
+    const victimComment = waitForQuestions(
+      mod, (qs) => qs[0] && qs[0].votes[0] && (qs[0].votes[0].comments || []).length === 1, 'victim comment');
+    victim.emit('addResponseComment', topic, victimResponseId, "victim's comment", 'victim-user', 'Victim');
+    const victimCommentId = (await victimComment)[0].votes[0].comments[0].id;
+
+    // The attacker also posts their own idea, so we can show what their socket can
+    // actually delete (its own content) versus what it cannot (the victim's).
+    const attackerIdea = waitForQuestions(mod, (qs) => qs[0] && qs[0].votes.length === 2, 'attacker idea');
+    attacker.emit('vote', topic, question.id, "attacker's idea", 'attacker-user', 'Attacker');
+    const attackerResponseId = (await attackerIdea)[0].votes.find((v) => v.id !== victimResponseId).id;
+
+    // ATTACK 1: delete the victim's idea by naming the victim's userId. The handler
+    // ignores the supplied id and acts as the attacker's pinned identity, so the
+    // delete matches nothing and the victim's idea survives. deleteVote always
+    // re-broadcasts, so the next 'questions' event confirms the query ran.
+    const afterDelete = waitForQuestions(mod, (qs) => qs[0], 'state after spoofed delete');
+    attacker.emit('deleteVote', topic, victimResponseId, 'victim-user');
+    const afterDeleteVotes = (await afterDelete)[0].votes;
+    assert.ok(afterDeleteVotes.find((v) => v.id === victimResponseId), "victim's idea must survive a spoofed delete");
+
+    // ATTACK 2: delete the victim's comment by naming their userId — must survive.
+    const afterCommentDelete = waitForQuestions(
+      mod, (qs) => qs[0] && qs[0].votes.find((v) => v.id === victimResponseId), 'state after spoofed comment delete');
+    attacker.emit('deleteResponseComment', topic, victimCommentId, 'victim-user');
+    const survivingComments = (await afterCommentDelete)[0].votes.find((v) => v.id === victimResponseId).comments || [];
+    assert.ok(survivingComments.find((c) => c.id === victimCommentId), "victim's comment must survive a spoofed delete");
+
+    // ATTACK 3: rename the victim's responses by naming their userId — must not take.
+    const afterRename = waitForQuestions(
+      mod, (qs) => qs[0] && qs[0].votes.find((v) => v.id === victimResponseId), 'state after spoofed rename');
+    attacker.emit('updateDisplayName', topic, 'victim-user', 'PWNED');
+    const victimVoteAfter = (await afterRename)[0].votes.find((v) => v.id === victimResponseId);
+    assert.equal(victimVoteAfter.pseudonym, 'Victim', "victim's display name must be unchanged by a spoofer");
+
+    // The supplied id is IGNORED, not honored: the attacker passing 'victim-user'
+    // to deleteVote deletes the ATTACKER'S OWN idea (their connection's pinned
+    // identity), proving ownership is the socket's, not the message's.
+    const ownDeleted = waitForQuestions(
+      mod, (qs) => qs[0] && !qs[0].votes.find((v) => v.id === attackerResponseId), 'attacker own idea removed');
+    attacker.emit('deleteVote', topic, attackerResponseId, 'victim-user');
+    const remaining = (await ownDeleted)[0].votes;
+    assert.ok(remaining.find((v) => v.id === victimResponseId), "victim's idea is still present");
+    assert.ok(!remaining.find((v) => v.id === attackerResponseId), "the attacker's own idea is what got deleted");
+  } finally {
+    mod.disconnect();
+    victim.disconnect();
+    attacker.disconnect();
   }
 });
 
@@ -1439,10 +1531,15 @@ test('Renaming updates stored comment pseudonyms, and comment tokens are namespa
   const topic = uniqueTopic('brainstorm-rename');
   const mod = await connectSocket();
   const participant = await connectSocket();
+  // The commenter is a different participant from the idea's author, on its own
+  // socket — identity is pinned per connection, so one socket can't post the idea
+  // as 'user-idea' and the comment as 'user-c'.
+  const commenter = await connectSocket();
 
   try {
     mod.emit('joinDiscussion', topic);
     participant.emit('joinDiscussion', topic);
+    commenter.emit('joinDiscussion', topic);
     const token = await claimModerator(mod, topic);
     const question = await addBrainstormQuestion(mod, topic, 'Rename test');
 
@@ -1456,7 +1553,7 @@ test('Renaming updates stored comment pseudonyms, and comment tokens are namespa
 
     const commentUpdate = waitForQuestions(
       mod, (qs) => qs[0] && qs[0].votes[0] && (qs[0].votes[0].comments || []).length === 1, 'comment added');
-    await emitWithAck(participant, 'addResponseComment', topic, responseId, 'My take', 'user-c', 'Critic');
+    await emitWithAck(commenter, 'addResponseComment', topic, responseId, 'My take', 'user-c', 'Critic');
     const comment = (await commentUpdate)[0].votes[0].comments[0];
     assert.equal(comment.pseudonym, 'Critic');
 
@@ -1474,11 +1571,12 @@ test('Renaming updates stored comment pseudonyms, and comment tokens are namespa
         qs[0].votes[0].comments[0].pseudonym === 'Reformed Critic',
       'comment renamed'
     );
-    participant.emit('updateDisplayName', topic, 'user-c', 'Reformed Critic');
+    commenter.emit('updateDisplayName', topic, 'user-c', 'Reformed Critic');
     await renamed;
   } finally {
     mod.disconnect();
     participant.disconnect();
+    commenter.disconnect();
   }
 });
 
@@ -1514,9 +1612,13 @@ test('Brainstorm authors cannot rate or react to their own idea', async () => {
 test('Brainstorm reactions can be narrowed to a creator-chosen set', async () => {
   const topic = uniqueTopic('brainstorm-reactset');
   const mod = await connectSocket();
+  // A separate browser reacts; the author socket can't also be the reactor
+  // (per-socket identity, and reacting to your own idea is rejected).
+  const reactor = await connectSocket();
 
   try {
     mod.emit('joinDiscussion', topic);
+    reactor.emit('joinDiscussion', topic);
     // A fresh discussion broadcasts the full default reaction catalog.
     const initial = await waitForEvent(mod, 'discussionState', (s) => Array.isArray(s.reactionKeys));
     assert.deepEqual(initial.reactionKeys, ['changed-mind', 'crux', 'follows', 'citation-needed', 'key-insight']);
@@ -1542,13 +1644,14 @@ test('Brainstorm reactions can be narrowed to a creator-chosen set', async () =>
     // A reaction outside the active set is rejected; one inside is accepted.
     const reactUpdate = waitForQuestions(
       mod, (qs) => qs[0] && qs[0].votes[0] && (qs[0].votes[0].reactionCounts || {}).crux === 1, 'crux counted');
-    mod.emit('toggleResponseReaction', topic, responseId, 'key-insight', 'user-react');
-    mod.emit('toggleResponseReaction', topic, responseId, 'crux', 'user-react');
+    reactor.emit('toggleResponseReaction', topic, responseId, 'key-insight', 'user-react');
+    reactor.emit('toggleResponseReaction', topic, responseId, 'crux', 'user-react');
     const counts = (await reactUpdate)[0].votes[0].reactionCounts;
     assert.equal(counts.crux, 1);
     assert.equal(counts['key-insight'], undefined, 'reaction outside the active set must be rejected');
   } finally {
     mod.disconnect();
+    reactor.disconnect();
   }
 });
 


### PR DESCRIPTION
Closes #38.

## What & why

Issue #38 flagged that ownership actions trusted a client-supplied `userId` field, so any participant could name another's id and act as them (delete their Brainstorm ideas, manipulate response votes, etc.). The earlier tokenization work (`getQuestions` emits per-response ownership tokens instead of raw ids) already stopped the raw `userId` from being broadcast — which removed the *observable* attack path — but the server still read identity from a per-message field rather than from the connection.

This change makes identity a **per-connection** property:

- New `bindSocketUser(socket, claimed)` helper pins a socket to the first id it presents (via `identify` on connect, or its first ownership action) and **ignores any different id named in later messages**.
- Every ownership handler now derives its actor from `socket.data.userId`, never from the per-message field: `vote`, `deleteVote`, `toggleResponseVote`, `setResponseRating`, `toggleResponseReaction`, `addResponseComment`, `deleteResponseComment`, `updateDisplayName`, `requestPseudonym`, `regeneratePseudonym`, `getBrainstormState`.

A socket can only ever act as the one identity it first claimed and cannot switch mid-connection. Combined with the already-shipped tokenization (an observer can't learn another participant's id), this closes the impersonation vectors in #38.

No client changes were required — the client already `identify`s on connect/reconnect, so the per-message `userId` it still sends is now only used to bootstrap an as-yet-unpinned socket and is otherwise ignored.

### Scope note
This makes `userId` an unspoofable-per-connection bearer secret. The one residual it does **not** address is a *leaked* id being replayed on a fresh connection — that's inherent to any client-held bearer identity and would require server-issued per-connection session credentials (a larger change, out of scope and unwarranted for this app's "trust the room" posture).

## Tests
- **New regression test** (`a participant cannot act as another by supplying their userId (issue #38)`): a socket pinned as `attacker-user` tries to delete/comment-delete/rename a `victim-user`'s content by passing the victim's id — all rejected — and a spoofed id is shown to be ignored in favor of the socket's pinned identity (the attacker's own idea is what gets deleted).
- Updated four existing brainstorm tests that faked two identities on a single socket to use a distinct socket per participant, which the new invariant requires (and which models reality — one browser = one socket = one identity).
- Full integration suite passes: **53/53**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)