### PR TITLE
Fix vote-validation, clustering NaN, and toggle-race bugs

### DIFF
--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -984,12 +984,18 @@ const DiscussionPage = () => {
     // Restore this user's own brainstorm ratings/reactions on join/reload. The
     // server only ever returns the requesting user's own selections.
     useEffect(() => {
-        if (!userId) return;
+        if (!userId) return undefined;
+        // Guard the async ack: this component is reused across discussions, so a
+        // late reply for the previous topic must not overwrite the new topic's
+        // brainstorm state.
+        let cancelled = false;
         socket.emit('getBrainstormState', topic, userId, (state) => {
+            if (cancelled) return;
             if (state) {
                 setMyBrainstorm({ ratings: state.ratings || {}, reactions: state.reactions || {} });
             }
         });
+        return () => { cancelled = true; };
     }, [topic, userId]);
 
     const handleAddQuestion = () => {

--- a/clustering.js
+++ b/clustering.js
@@ -212,7 +212,15 @@ function silhouette(matrix, assignments, k) {
       }
     }
     if (b !== Infinity) {
-      total += (b - a) / Math.max(a, b);
+      // When a point is identical to every member of both its own cluster and
+      // the nearest one, a and b are both 0; the silhouette term is defined as 0
+      // there. Guarding the division keeps a single 0/0 from turning the whole
+      // score into NaN, which would make `score > best.score` always false and
+      // silently drop that k from selection.
+      const denom = Math.max(a, b);
+      if (denom > 0) {
+        total += (b - a) / denom;
+      }
     }
   }
   return total / n;

--- a/server.js
+++ b/server.js
@@ -887,7 +887,13 @@ io.on('connection', (socket) => {
       // create/edit time, never when a vote is cast. getQuestionRange supplies
       // the 0..100 default for legacy questions with null bounds.
       if (target.type === 'Numerical') {
-        const num = Number(vote);
+        // Require a real scalar numeric value before range-checking. Number('')
+        // / Number([]) / Number(null) all coerce to 0, which would otherwise
+        // slip past the range check for any range that includes 0 and let
+        // addVote persist the original non-numeric payload.
+        const isNumber = typeof vote === 'number';
+        const isNumericString = typeof vote === 'string' && vote.trim() !== '';
+        const num = isNumber ? vote : isNumericString ? Number(vote) : NaN;
         const { minValue, maxValue } = getQuestionRange({ min_value: target.minValue, max_value: target.maxValue });
         if (!Number.isFinite(num) || num < minValue || num > maxValue) {
           socket.emit('error', { message: 'Invalid vote.' });
@@ -2967,13 +2973,17 @@ async function toggleResponseVote(topic, responseId, userId) {
     console.log('Ignoring self-upvote on response', responseId);
     return;
   }
-  // Run the delete-or-insert as one transaction on a single connection so two
-  // concurrent toggles from the same user (double-click, two tabs) can't
-  // interleave their DELETE/INSERT across separate pooled connections and land
-  // in the wrong on/off state.
+  // Serialize concurrent toggles from the same user (double-click, two tabs) on
+  // this response. A plain transaction is not enough under Read Committed: when
+  // no row exists yet, both toggles' DELETEs see 0 rows, both INSERT, and
+  // ON CONFLICT silently drops one — leaving the vote ON after two toggles that
+  // should cancel out. A transaction-scoped advisory lock keyed on
+  // (response, user) forces the second toggle to wait for the first to commit,
+  // then re-read the now-current state and flip it correctly.
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
+    await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [`response_vote:${responseId}:${userId}`]);
     const deleteResult = await client.query(
       'DELETE FROM response_votes WHERE response_id = $1 AND user_id = $2',
       [responseId, userId]
@@ -3044,11 +3054,13 @@ async function setResponseRating(responseId, userId, axis, value) {
 // Toggle a single epistemic reaction for a user on a response: remove it if
 // present, add it otherwise.
 async function toggleResponseReaction(responseId, userId, reaction) {
-  // Atomic delete-or-insert (see toggleResponseVote) so concurrent toggles of
-  // the same reaction can't interleave into the wrong on/off state.
+  // Serialize concurrent toggles of the same reaction (see toggleResponseVote);
+  // the advisory lock is keyed on (response, user, reaction) so it also closes
+  // the absent-row race a bare transaction leaves open.
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
+    await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [`response_reaction:${responseId}:${userId}:${reaction}`]);
     const deleteResult = await client.query(
       'DELETE FROM response_reactions WHERE response_id = $1 AND user_id = $2 AND reaction = $3',
       [responseId, userId, reaction]

--- a/server.js
+++ b/server.js
@@ -880,6 +880,20 @@ io.on('connection', (socket) => {
         socket.emit('error', { message: 'Invalid vote.' });
         return;
       }
+      // Numerical votes must be a finite number within the question's configured
+      // range. Without this, a crafted socket message could store out-of-range
+      // (or non-numeric) values that silently skew the average / std-dev / spread
+      // shown in the summary — the range is otherwise only enforced at
+      // create/edit time, never when a vote is cast. getQuestionRange supplies
+      // the 0..100 default for legacy questions with null bounds.
+      if (target.type === 'Numerical') {
+        const num = Number(vote);
+        const { minValue, maxValue } = getQuestionRange({ min_value: target.minValue, max_value: target.maxValue });
+        if (!Number.isFinite(num) || num < minValue || num > maxValue) {
+          socket.emit('error', { message: 'Invalid vote.' });
+          return;
+        }
+      }
       // Persist the reserved handle in pseudonym mode rather than the client's
       // (possibly pre-reservation, colliding) local pick — see canonicalPseudonym.
       const handle = await canonicalPseudonym(discussionSlug, target.discussionId, userId, mode, pseudonym);
@@ -2577,7 +2591,7 @@ async function isModeratorOnlyQuestions(topic) {
 async function getQuestionForTopic(topic, questionId) {
   const slug = slugifyTopic(topic);
   const result = await pool.query(
-    `SELECT q.id, q.type, q.discussion_id, d.locked
+    `SELECT q.id, q.type, q.discussion_id, q.min_value, q.max_value, d.locked
      FROM questions q
      JOIN discussions d ON q.discussion_id = d.id
      WHERE d.slug = $1 AND q.id = $2`,
@@ -2588,6 +2602,8 @@ async function getQuestionForTopic(topic, questionId) {
     id: result.rows[0].id,
     type: result.rows[0].type,
     discussionId: result.rows[0].discussion_id,
+    minValue: result.rows[0].min_value,
+    maxValue: result.rows[0].max_value,
     locked: result.rows[0].locked === true,
   };
 }
@@ -2951,15 +2967,29 @@ async function toggleResponseVote(topic, responseId, userId) {
     console.log('Ignoring self-upvote on response', responseId);
     return;
   }
-  const deleteResult = await pool.query(
-    'DELETE FROM response_votes WHERE response_id = $1 AND user_id = $2',
-    [responseId, userId]
-  );
-  if (deleteResult.rowCount === 0) {
-    await pool.query(
-      'INSERT INTO response_votes (response_id, user_id) VALUES ($1, $2) ON CONFLICT DO NOTHING',
+  // Run the delete-or-insert as one transaction on a single connection so two
+  // concurrent toggles from the same user (double-click, two tabs) can't
+  // interleave their DELETE/INSERT across separate pooled connections and land
+  // in the wrong on/off state.
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const deleteResult = await client.query(
+      'DELETE FROM response_votes WHERE response_id = $1 AND user_id = $2',
       [responseId, userId]
     );
+    if (deleteResult.rowCount === 0) {
+      await client.query(
+        'INSERT INTO response_votes (response_id, user_id) VALUES ($1, $2) ON CONFLICT DO NOTHING',
+        [responseId, userId]
+      );
+    }
+    await client.query('COMMIT');
+  } catch (e) {
+    await client.query('ROLLBACK');
+    throw e;
+  } finally {
+    client.release();
   }
 }
 
@@ -3014,15 +3044,27 @@ async function setResponseRating(responseId, userId, axis, value) {
 // Toggle a single epistemic reaction for a user on a response: remove it if
 // present, add it otherwise.
 async function toggleResponseReaction(responseId, userId, reaction) {
-  const deleteResult = await pool.query(
-    'DELETE FROM response_reactions WHERE response_id = $1 AND user_id = $2 AND reaction = $3',
-    [responseId, userId, reaction]
-  );
-  if (deleteResult.rowCount === 0) {
-    await pool.query(
-      'INSERT INTO response_reactions (response_id, user_id, reaction) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING',
+  // Atomic delete-or-insert (see toggleResponseVote) so concurrent toggles of
+  // the same reaction can't interleave into the wrong on/off state.
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const deleteResult = await client.query(
+      'DELETE FROM response_reactions WHERE response_id = $1 AND user_id = $2 AND reaction = $3',
       [responseId, userId, reaction]
     );
+    if (deleteResult.rowCount === 0) {
+      await client.query(
+        'INSERT INTO response_reactions (response_id, user_id, reaction) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING',
+        [responseId, userId, reaction]
+      );
+    }
+    await client.query('COMMIT');
+  } catch (e) {
+    await client.query('ROLLBACK');
+    throw e;
+  } finally {
+    client.release();
   }
 }
 

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -346,7 +346,17 @@ test('a Numerical vote outside the question range (or non-numeric) is rejected, 
     voter.emit('vote', topic, question.id, 'lots', 'attacker', 'Mallory');
     await notNumeric;
 
-    // Neither crafted value was written.
+    // Payloads that Number() silently coerces to 0 ('' and []) must NOT slip
+    // through just because this question's range includes 0.
+    const blank = waitForEvent(voter, 'error', (e) => /invalid vote/i.test(e.message));
+    voter.emit('vote', topic, question.id, '', 'attacker', 'Mallory');
+    await blank;
+
+    const nonScalar = waitForEvent(voter, 'error', (e) => /invalid vote/i.test(e.message));
+    voter.emit('vote', topic, question.id, [], 'attacker', 'Mallory');
+    await nonScalar;
+
+    // None of the crafted values were written.
     const rejected = await pool.query('SELECT COUNT(*)::int AS n FROM votes');
     assert.equal(rejected.rows[0].n, 0);
 

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -321,6 +321,49 @@ test('a crafted Agreement/Yes-No vote with an unknown value is rejected, not sto
   }
 });
 
+test('a Numerical vote outside the question range (or non-numeric) is rejected, not stored', async () => {
+  const topic = uniqueTopic('numerical-validation');
+  const author = await connectSocket();
+  const voter = await connectSocket();
+
+  try {
+    author.emit('joinDiscussion', topic);
+    voter.emit('joinDiscussion', topic);
+
+    const added = waitForQuestions(author, (qs) => qs.some((q) => q.text === 'Budget?'), 'numerical added');
+    author.emit('addQuestion', topic, { text: 'Budget?', type: 'Numerical', minValue: 0, maxValue: 10, options: [] });
+    const question = (await added).find((q) => q.text === 'Budget?');
+
+    // An out-of-range value is rejected server-side: the range is otherwise only
+    // enforced at create/edit time, so an unchecked vote would silently skew the
+    // average / std-dev / spread shown in the summary.
+    const tooHigh = waitForEvent(voter, 'error', (e) => /invalid vote/i.test(e.message));
+    voter.emit('vote', topic, question.id, '999', 'attacker', 'Mallory');
+    await tooHigh;
+
+    // A non-numeric value is rejected too.
+    const notNumeric = waitForEvent(voter, 'error', (e) => /invalid vote/i.test(e.message));
+    voter.emit('vote', topic, question.id, 'lots', 'attacker', 'Mallory');
+    await notNumeric;
+
+    // Neither crafted value was written.
+    const rejected = await pool.query('SELECT COUNT(*)::int AS n FROM votes');
+    assert.equal(rejected.rows[0].n, 0);
+
+    // An in-range value is accepted and stored normally.
+    const accepted = waitForQuestions(
+      voter,
+      (qs) => qs[0] && qs[0].votes.length === 1,
+      'in-range vote broadcast'
+    );
+    voter.emit('vote', topic, question.id, '5', 'good-user', 'Honest Heron');
+    assert.equal((await accepted)[0].votes[0].value, '5');
+  } finally {
+    author.disconnect();
+    voter.disconnect();
+  }
+});
+
 test('Socket.IO sanitizes display names: anonymous stores null, long names are clamped', async () => {
   const topic = uniqueTopic('names');
   const author = await connectSocket();


### PR DESCRIPTION
- server: range-check Numerical votes in the vote handler (only Agreement
  and Yes/No were validated), so out-of-range or non-numeric values can no
  longer be stored and skew the summary's average/std-dev/spread. Adds
  min_value/max_value to getQuestionForTopic so the bounds are available.
- clustering: guard the silhouette division against 0/0. When a point was
  identical to every member of both its own and the nearest cluster, the
  resulting NaN poisoned the whole score and silently dropped that k from
  selection.
- server: make toggleResponseVote / toggleResponseReaction atomic by running
  the delete-or-insert in a single transaction, so concurrent toggles from
  the same user can't interleave into the wrong on/off state.
- client: add a cancellation guard to the getBrainstormState effect so a late
  ack for a previous discussion can't overwrite the new discussion's state.
- tests: add a regression test for Numerical vote validation.

https://claude.ai/code/session_01Paww4gyzZJKBWJ36T54dcg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed brainstorm ratings and reactions being overwritten when navigating away
  * Fixed clustering algorithm calculation errors for optimal cluster selection
  * Added validation to ensure numerical votes fall within configured ranges
  * Prevented vote toggles from becoming inconsistent with concurrent requests

* **Tests**
  * Added test coverage for numerical vote validation edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->