### PR TITLE
Let moderators rename a discussion

### DIFF
--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -765,9 +765,13 @@ const DiscussionPage = () => {
         });
     };
 
-    // Open the inline title editor, seeding it with the current title.
+    // Open the inline title editor, seeding it with the loaded discussion's
+    // actual title. Guard until the discussion has loaded so we never seed the
+    // editor from the route slug (or a previous room) and then save THAT as the
+    // new title; the Rename button is also disabled until then.
     const handleStartRename = () => {
-        setTitleDraft(discussion?.topic || discussionTitle);
+        if (!discussion?.topic) return;
+        setTitleDraft(discussion.topic);
         setEditingTitle(true);
     };
 
@@ -786,6 +790,9 @@ const DiscussionPage = () => {
                 setEditingTitle(false);
             } else if (resp && resp.reason === 'not_authorized') {
                 setError('You are no longer a moderator of this discussion.');
+            } else if (resp && resp.reason === 'duplicate') {
+                // Keep the editor open so the moderator can correct the name.
+                setError('A discussion with that name already exists. Choose a different name.');
             } else {
                 setError('Could not rename the discussion. Try again.');
             }
@@ -980,6 +987,15 @@ const DiscussionPage = () => {
         setPseudonymReserved(false);
         shufflePendingRef.current = false;
         setShufflePending(false);
+    }, [discussionSlug]);
+
+    // The rename editor is scoped to one discussion. This component is reused
+    // across /discussion/:topic routes (only the param changes), so close any
+    // open editor and clear its draft when the slug changes — otherwise a draft
+    // seeded in one room could be saved into another the next time it's opened.
+    useEffect(() => {
+        setEditingTitle(false);
+        setTitleDraft('');
     }, [discussionSlug]);
 
     // Ask the server for a handle that's unique within this discussion. We wait
@@ -1650,7 +1666,7 @@ const DiscussionPage = () => {
                         <span className="font-semibold text-indigo-800">You&apos;re the moderator</span>
                         <button
                             onClick={handleStartRename}
-                            disabled={editingTitle}
+                            disabled={editingTitle || !discussion?.topic}
                             className="px-3 py-1 rounded bg-white border border-indigo-300 text-indigo-700 hover:bg-indigo-100 disabled:opacity-50"
                             title="Change the discussion's name"
                         >

--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -176,6 +176,10 @@ const DiscussionPage = () => {
     const [editingIdentity, setEditingIdentity] = useState(false);
     const [error, setError] = useState(null);
     const [newTopicName, setNewTopicName] = useState('');
+    // Inline moderator rename of the discussion title. titleDraft holds the
+    // in-progress edit; editingTitle swaps the <h1> for the editor.
+    const [editingTitle, setEditingTitle] = useState(false);
+    const [titleDraft, setTitleDraft] = useState('');
     const [showDuplicateModal, setShowDuplicateModal] = useState(false);
     const [showShareModal, setShowShareModal] = useState(false);
     const [showActionsMenu, setShowActionsMenu] = useState(false);
@@ -761,6 +765,33 @@ const DiscussionPage = () => {
         });
     };
 
+    // Open the inline title editor, seeding it with the current title.
+    const handleStartRename = () => {
+        setTitleDraft(discussion?.topic || discussionTitle);
+        setEditingTitle(true);
+    };
+
+    // Persist a renamed discussion. Only the display title changes server-side;
+    // the slug (and thus this page's URL and everyone's room) stays put, so the
+    // ack is the only thing we wait on before closing the editor. The new title
+    // arrives for everyone — us included — over the broadcast 'discussion' event.
+    const handleRenameDiscussion = () => {
+        const trimmed = titleDraft.trim();
+        if (!trimmed) {
+            setError('Discussion name cannot be empty.');
+            return;
+        }
+        socket.emit('setTopic', discussionSlug, trimmed, adminToken, (resp) => {
+            if (resp && resp.updated) {
+                setEditingTitle(false);
+            } else if (resp && resp.reason === 'not_authorized') {
+                setError('You are no longer a moderator of this discussion.');
+            } else {
+                setError('Could not rename the discussion. Try again.');
+            }
+        });
+    };
+
     const handleDuplicateDiscussion = async () => {
         if (newTopicName.trim() === '') {
             setError('New topic name cannot be empty.');
@@ -1337,7 +1368,40 @@ const DiscussionPage = () => {
 
     return (
         <div className="max-w-4xl mx-auto mt-10 px-4">
-            <h1 className="text-4xl font-bold mb-2 text-center text-gray-800">Discussion: {discussionTitle}</h1>
+            {isAdmin && editingTitle ? (
+                <div className="mb-2 flex flex-col items-center gap-2">
+                    <input
+                        type="text"
+                        value={titleDraft}
+                        onChange={(e) => setTitleDraft(e.target.value)}
+                        onKeyDown={(e) => {
+                            if (e.key === 'Enter') handleRenameDiscussion();
+                            if (e.key === 'Escape') setEditingTitle(false);
+                        }}
+                        autoFocus
+                        maxLength={200}
+                        placeholder="Discussion name"
+                        aria-label="Discussion name"
+                        className="w-full max-w-xl p-2 border rounded text-3xl font-bold text-center text-gray-800"
+                    />
+                    <div className="flex gap-2">
+                        <button
+                            onClick={handleRenameDiscussion}
+                            className="px-3 py-1 rounded bg-primary text-white hover:bg-opacity-90"
+                        >
+                            Save
+                        </button>
+                        <button
+                            onClick={() => setEditingTitle(false)}
+                            className="px-3 py-1 rounded bg-gray-300 hover:bg-gray-400"
+                        >
+                            Cancel
+                        </button>
+                    </div>
+                </div>
+            ) : (
+                <h1 className="text-4xl font-bold mb-2 text-center text-gray-800">Discussion: {discussionTitle}</h1>
+            )}
 
             {/* Participant identity + live presence */}
             <div className="mb-8 text-center text-sm text-gray-600">
@@ -1584,6 +1648,14 @@ const DiscussionPage = () => {
                 {isAdmin ? (
                     <div className="flex flex-wrap items-center gap-3 bg-indigo-50 border border-indigo-100 rounded-md p-3 text-sm">
                         <span className="font-semibold text-indigo-800">You&apos;re the moderator</span>
+                        <button
+                            onClick={handleStartRename}
+                            disabled={editingTitle}
+                            className="px-3 py-1 rounded bg-white border border-indigo-300 text-indigo-700 hover:bg-indigo-100 disabled:opacity-50"
+                            title="Change the discussion's name"
+                        >
+                            Rename discussion
+                        </button>
                         <button
                             onClick={handleToggleLock}
                             className="px-3 py-1 rounded bg-white border border-indigo-300 text-indigo-700 hover:bg-indigo-100"

--- a/server.js
+++ b/server.js
@@ -1156,6 +1156,14 @@ io.on('connection', (socket) => {
       io.to(discussionSlug).emit('discussion', await getDiscussionBySlug(discussionSlug));
       reply({ updated: true });
     } catch (error) {
+      // discussions.topic is unique (discussions_topic_unique); renaming to an
+      // existing title raises a Postgres unique-violation. Surface it as a
+      // distinct, actionable reason so the moderator can pick another name
+      // instead of seeing a generic failure.
+      if (error?.code === '23505') {
+        reply({ updated: false, reason: 'duplicate' });
+        return;
+      }
       console.error('Error setting topic:', error);
       socket.emit('error', { message: 'Failed to rename discussion' });
       reply({ updated: false, reason: 'error' });

--- a/server.js
+++ b/server.js
@@ -98,6 +98,12 @@ function formatTopicTitle(value) {
   return 'Discussion';
 }
 
+// Upper bound on a discussion's display title. The slug (the real routing key)
+// is already capped at 80 chars in slugifyTopic; the title can be longer and
+// more readable, but we still bound it so a rename can't store an unbounded
+// blob. Kept in sync with the maxLength on the client's rename input.
+const MAX_TOPIC_LENGTH = 200;
+
 function titleFromSlug(slug) {
   return slugifyTopic(slug)
     .split('-')
@@ -1119,6 +1125,40 @@ io.on('connection', (socket) => {
     } catch (error) {
       console.error('Error setting theme:', error);
       socket.emit('error', { message: 'Failed to update discussion' });
+    }
+  });
+
+  // Moderator-only: rename the discussion (change its display title). Only the
+  // `topic` column is touched — the slug is the stable identifier every
+  // participant's URL and socket room is keyed on, so we deliberately leave it
+  // unchanged. A rename therefore never invalidates existing links or evicts
+  // anyone from the room. The new title is broadcast on the same `discussion`
+  // channel that carries it on join, so every open tab updates live.
+  socket.on('setTopic', async (topic, newTopic, token, ack) => {
+    const discussionSlug = slugifyTopic(topic);
+    const reply = (result) => { if (typeof ack === 'function') ack(result); };
+    try {
+      const discussionId = await verifyAdmin(discussionSlug, token);
+      if (!discussionId) {
+        socket.emit('error', { message: 'Not authorized to moderate this discussion.' });
+        reply({ updated: false, reason: 'not_authorized' });
+        return;
+      }
+      // formatTopicTitle substitutes 'Discussion' for blank input, so guard on
+      // the raw value first: a blank submission is invalid, not a silent rename
+      // to the placeholder. Also bound the length to match the client input.
+      const title = formatTopicTitle(newTopic);
+      if (!String(newTopic || '').trim() || title.length > MAX_TOPIC_LENGTH) {
+        reply({ updated: false, reason: 'invalid' });
+        return;
+      }
+      await pool.query('UPDATE discussions SET topic = $1 WHERE id = $2', [title, discussionId]);
+      io.to(discussionSlug).emit('discussion', await getDiscussionBySlug(discussionSlug));
+      reply({ updated: true });
+    } catch (error) {
+      console.error('Error setting topic:', error);
+      socket.emit('error', { message: 'Failed to rename discussion' });
+      reply({ updated: false, reason: 'error' });
     }
   });
 

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -814,6 +814,86 @@ test('a non-moderator cannot set the discussion theme', async () => {
   }
 });
 
+test('a moderator can rename the discussion while the slug stays stable', async () => {
+  const topic = uniqueTopic('rename');
+  const creator = await jsonRequest('POST', '/api/discussions', { topic });
+  const adminToken = creator.body.adminToken;
+  const slug = creator.body.slug;
+
+  const mod = await connectSocket();
+  const guest = await connectSocket();
+
+  try {
+    mod.emit('joinDiscussion', topic);
+    guest.emit('joinDiscussion', topic);
+    await waitForEvent(guest, 'discussion', (d) => d && d.topic === topic);
+
+    // The moderator renames; everyone in the room receives the new title on the
+    // same 'discussion' channel that delivered it on join.
+    const renamed = waitForEvent(guest, 'discussion', (d) => d && d.topic === 'Renamed Topic');
+    const ack = await emitWithAck(mod, 'setTopic', slug, 'Renamed Topic', adminToken);
+    assert.deepEqual(ack, { updated: true });
+    const broadcast = await renamed;
+
+    // Only the display title changed: the slug (the routing key every URL and
+    // socket room is keyed on) is untouched, so existing links stay valid.
+    assert.equal(broadcast.slug, slug);
+
+    // The rename persists: a fresh join, addressing the discussion by its
+    // unchanged slug, reports the new title.
+    const rejoin = await connectSocket();
+    try {
+      rejoin.emit('joinDiscussion', slug);
+      const state = await waitForEvent(rejoin, 'discussion', (d) => d && d.slug === slug);
+      assert.equal(state.topic, 'Renamed Topic');
+    } finally {
+      rejoin.disconnect();
+    }
+  } finally {
+    mod.disconnect();
+    guest.disconnect();
+  }
+});
+
+test('renaming is rejected for non-moderators and blank titles', async () => {
+  const topic = uniqueTopic('rename-deny');
+  const creator = await jsonRequest('POST', '/api/discussions', { topic });
+  const adminToken = creator.body.adminToken;
+  const slug = creator.body.slug;
+
+  const stranger = await connectSocket();
+  const mod = await connectSocket();
+
+  try {
+    stranger.emit('joinDiscussion', topic);
+    mod.emit('joinDiscussion', topic);
+
+    // No valid moderator token: rejected, with an error surfaced to the sender.
+    const rejected = waitForEvent(stranger, 'error', (e) => /authoriz/i.test(e.message));
+    const denyAck = await emitWithAck(stranger, 'setTopic', slug, 'Hijacked', 'bogus-token');
+    assert.deepEqual(denyAck, { updated: false, reason: 'not_authorized' });
+    await rejected;
+
+    // A moderator submitting a blank title is rejected rather than renamed to
+    // the 'Discussion' placeholder formatTopicTitle would otherwise produce.
+    const blankAck = await emitWithAck(mod, 'setTopic', slug, '   ', adminToken);
+    assert.deepEqual(blankAck, { updated: false, reason: 'invalid' });
+
+    // Neither attempt changed the stored title.
+    const observer = await connectSocket();
+    try {
+      observer.emit('joinDiscussion', slug);
+      const state = await waitForEvent(observer, 'discussion', (d) => d && d.slug === slug);
+      assert.equal(state.topic, topic);
+    } finally {
+      observer.disconnect();
+    }
+  } finally {
+    stranger.disconnect();
+    mod.disconnect();
+  }
+});
+
 test('a non-moderator cannot list or promote participants', async () => {
   const topic = uniqueTopic('promote-deny');
   await jsonRequest('POST', '/api/discussions', { topic });

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -894,6 +894,47 @@ test('renaming is rejected for non-moderators and blank titles', async () => {
   }
 });
 
+test('renaming to an existing discussion title is rejected as a duplicate', async () => {
+  // discussions.topic is unique, so renaming one discussion to another's exact
+  // title raises a Postgres unique-violation. The server should surface that as
+  // a distinct 'duplicate' reason (not a generic error) and leave both titles
+  // untouched so the moderator can pick a different name.
+  const topicA = uniqueTopic('rename-dup-a');
+  const topicB = uniqueTopic('rename-dup-b');
+  const creatorA = await jsonRequest('POST', '/api/discussions', { topic: topicA });
+  const creatorB = await jsonRequest('POST', '/api/discussions', { topic: topicB });
+  const adminTokenA = creatorA.body.adminToken;
+  const slugA = creatorA.body.slug;
+  const slugB = creatorB.body.slug;
+
+  const mod = await connectSocket();
+  try {
+    mod.emit('joinDiscussion', topicA);
+
+    // Moderator of A tries to rename A to B's exact title: rejected as duplicate.
+    const dupAck = await emitWithAck(mod, 'setTopic', slugA, topicB, adminTokenA);
+    assert.deepEqual(dupAck, { updated: false, reason: 'duplicate' });
+
+    // Neither title changed: A still reads topicA, B still reads topicB.
+    const observerA = await connectSocket();
+    const observerB = await connectSocket();
+    try {
+      observerA.emit('joinDiscussion', slugA);
+      const stateA = await waitForEvent(observerA, 'discussion', (d) => d && d.slug === slugA);
+      assert.equal(stateA.topic, topicA);
+
+      observerB.emit('joinDiscussion', slugB);
+      const stateB = await waitForEvent(observerB, 'discussion', (d) => d && d.slug === slugB);
+      assert.equal(stateB.topic, topicB);
+    } finally {
+      observerA.disconnect();
+      observerB.disconnect();
+    }
+  } finally {
+    mod.disconnect();
+  }
+});
+
 test('a non-moderator cannot list or promote participants', async () => {
   const topic = uniqueTopic('promote-deny');
   await jsonRequest('POST', '/api/discussions', { topic });


### PR DESCRIPTION
Adds a moderator-only `setTopic` socket event and an inline title editor so a discussion's display name can be changed after creation. Only the `topic` column is updated — the slug, which is the stable routing key for URLs and socket rooms, is deliberately left untouched, so renaming never breaks existing links or evicts participants. The new title is rebroadcast on the `discussion` channel so every open tab updates live. The change is gated by `verifyAdmin()` and rejects blank or over-long titles. Covered by two new integration tests (full suite: 61 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added discussion title rename capability for moderators via an inline editor with Enter-to-save and Escape-to-cancel functionality.
  * Real-time title updates broadcast to all participants in the discussion.
  * Title validation prevents empty submissions and enforces maximum length constraints.
  * Clear error messaging for authorization failures.

* **Tests**
  * Added integration tests verifying moderator rename permissions and title persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->