### PR TITLE
Fix unreliable "people here now" participant count

### DIFF
--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -933,7 +933,15 @@ const DiscussionPage = () => {
     useEffect(() => {
         if (topic !== discussionSlug) return undefined;
         console.log('Current topic:', discussionSlug);
-        socket.emit('joinDiscussion', discussionSlug);
+        // Re-join on every (re)connect, not just on mount. When a socket drops
+        // and Socket.IO reconnects (routine on mobile / sleeping tabs), the
+        // server sees a brand-new socket that belongs to no room — so without
+        // this the client silently stops counting toward presence and stops
+        // receiving room updates. Mirrors the identify effect below, which
+        // already re-fires on 'connect' for the same reason.
+        const joinRoom = () => socket.emit('joinDiscussion', discussionSlug);
+        joinRoom();
+        socket.on('connect', joinRoom);
         socket.on('discussion', setDiscussion);
         socket.on('questions', handleQuestionsUpdate);
         socket.on('presence', setPresence);
@@ -946,6 +954,7 @@ const DiscussionPage = () => {
             // Leave the room so the server stops counting this client toward the
             // discussion's presence once the page unmounts (e.g. navigating home).
             socket.emit('leaveDiscussion', discussionSlug);
+            socket.off('connect', joinRoom);
             socket.off('discussion', setDiscussion);
             socket.off('questions', handleQuestionsUpdate);
             socket.off('presence', setPresence);

--- a/server.js
+++ b/server.js
@@ -637,11 +637,25 @@ async function getDiscussionBySlug(slug) {
 app.use(express.json());
 app.use(express.static(path.join(__dirname, 'dist')));
 
-// Emit the number of clients currently in a discussion room to everyone there.
+// Emit the number of distinct PEOPLE currently in a discussion room to everyone
+// there. We count by identity, not by raw socket: a single person routinely
+// holds several sockets at once — a second browser tab, or (very common on
+// mobile) a connection that just dropped but whose server-side timeout hasn't
+// fired yet while its reconnected replacement is already in the room. Counting
+// sockets reported those as extra "people" — the "it says 2 but there's no one
+// else here" symptom. Sockets that haven't run `identify` yet fall back to
+// their own id, so several genuinely anonymous viewers still each count once.
 function emitPresence(topic) {
   if (!topic) return;
-  const count = io.sockets.adapter.rooms.get(topic)?.size || 0;
-  io.to(topic).emit('presence', count);
+  const room = io.sockets.adapter.rooms.get(topic);
+  const people = new Set();
+  if (room) {
+    for (const socketId of room) {
+      const member = io.sockets.sockets.get(socketId);
+      people.add(member?.data.userId || socketId);
+    }
+  }
+  io.to(topic).emit('presence', people.size);
 }
 
 // Push a freshly reserved handle to a user's OTHER sockets in a discussion (all
@@ -772,7 +786,15 @@ io.on('connection', (socket) => {
   // token live at promotion time and persists it locally (so it survives reloads /
   // reconnects via verifyAdmin); we never re-mint it from the id alone.
   socket.on('identify', (topic, userId) => {
+    const wasAnonymous = !socket.data.userId;
     bindSocketUser(socket, userId);
+    // `joinDiscussion` usually arrives before `identify`, so the presence count
+    // broadcast on join may have counted this socket as its own anonymous person.
+    // Now that we know who it is, recompute so it merges with the user's other
+    // sockets instead of inflating the count until the next join/leave.
+    if (wasAnonymous && socket.data.userId && socket.data.topic) {
+      emitPresence(socket.data.topic);
+    }
   });
 
   socket.on('leaveDiscussion', (topic) => {

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -1029,6 +1029,44 @@ test('promoting an offline participant fails and does not leave a dangling grant
   }
 });
 
+test('presence counts distinct people, not sockets', async () => {
+  const topic = uniqueTopic('presence-dedup');
+  await jsonRequest('POST', '/api/discussions', { topic });
+
+  const tabA = await connectSocket();
+  const tabB = await connectSocket();
+  const other = await connectSocket();
+
+  // Join + identify a socket, then wait until its presence count settles to
+  // `expected`. Also wait for the server's per-join 'questions' emit so the
+  // join's DB reads have flushed before we move on — otherwise a read left in
+  // flight when the test ends can deadlock the next test's TRUNCATE.
+  const joinAs = async (sock, userId, expected) => {
+    const ready = waitForQuestions(sock, () => true, `${userId} join`);
+    const settled = waitForEvent(sock, 'presence', (count) => count === expected);
+    sock.emit('joinDiscussion', topic);
+    sock.emit('identify', topic, userId);
+    await ready;
+    assert.equal(await settled, expected);
+  };
+
+  try {
+    await joinAs(tabA, 'person-1', 1);  // one person opens the discussion
+    await joinAs(tabB, 'person-1', 1);  // same person, second tab → still one person
+    await joinAs(other, 'person-2', 2); // a genuinely different person → two
+
+    // The first person closes one of their two tabs. They are still here via the
+    // other tab, so the count broadcast on that disconnect must remain 2.
+    const afterTabClose = waitForEvent(other, 'presence');
+    tabB.disconnect();
+    assert.equal(await afterTabClose, 2);
+  } finally {
+    tabA.disconnect();
+    tabB.disconnect();
+    other.disconnect();
+  }
+});
+
 test('the creator can remove a moderator, revoking their access live', async () => {
   const topic = uniqueTopic('demote');
   const creator = await jsonRequest('POST', '/api/discussions', { topic });


### PR DESCRIPTION
The live "people here now" count was counted by raw socket connections, so one person holding several sockets — a second tab, or a just-dropped mobile connection whose timeout hadn't fired yet — was double-counted (the "it says 2 but no one else is here" symptom); `emitPresence` now counts distinct identities, and `identify` re-broadcasts so a just-joined socket collapses into its user once known. Separately, the client only emitted `joinDiscussion` on mount, so a socket that dropped and reconnected (routine on mobile) never rejoined its room and silently stopped counting toward presence — the join effect now re-emits on every reconnect, mirroring the existing `identify` effect. This is distinct from the *Participants* list, which intentionally only shows people who have voted or posted. Adds an integration test covering distinct-person counting (two tabs from one user count once; a different user makes two; closing one tab keeps the count). All 64 integration tests pass and the client builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed presence count to accurately reflect distinct users in discussions, rather than counting multiple connections from the same user separately.
  * Improved reliability of rejoining discussion rooms after network reconnections.

* **Tests**
  * Added integration test for presence counting accuracy across multiple connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->