### PR TITLE
Add moderator short links

### DIFF
--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -186,6 +186,8 @@ const DiscussionPage = () => {
     const [presence, setPresence] = useState(0);
     const [copied, setCopied] = useState(false);
     const [shortShareUrl, setShortShareUrl] = useState('');
+    const [shortCodeDraft, setShortCodeDraft] = useState('');
+    const [shortLinkError, setShortLinkError] = useState('');
     const [shortLinkLoading, setShortLinkLoading] = useState(false);
     const [shortLinkCopied, setShortLinkCopied] = useState(false);
     const [adminToken, setAdminToken] = useState(null);
@@ -240,6 +242,7 @@ const DiscussionPage = () => {
     const adminUrl = typeof window !== 'undefined' && adminToken
         ? `${window.location.origin}/discussion/${discussionSlug}?admin=${adminToken}`
         : '';
+    const shortUrlPrefix = typeof window !== 'undefined' ? `${window.location.origin}/s/` : '/s/';
 
     useEffect(() => {
         setShortShareUrl(
@@ -247,6 +250,8 @@ const DiscussionPage = () => {
                 ? `${window.location.origin}/s/${discussion.short_code}`
                 : ''
         );
+        setShortCodeDraft(discussion?.short_code || '');
+        setShortLinkError('');
         setShortLinkCopied(false);
     }, [discussionSlug, discussion?.short_code]);
 
@@ -727,21 +732,31 @@ const DiscussionPage = () => {
         }
     };
 
-    const handleGenerateShortLink = async () => {
+    const saveShortLink = async (requestedCode) => {
         if (!adminToken || shortLinkLoading) return;
         setShortLinkLoading(true);
+        setShortLinkError('');
         try {
             const response = await fetch(`/api/discussions/${encodeURIComponent(discussionSlug)}/short-link`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ adminToken }),
+                body: JSON.stringify({ adminToken, ...(requestedCode ? { shortCode: requestedCode } : {}) }),
             });
             if (!response.ok) {
-                throw new Error('Failed to generate short link');
+                if (response.status === 409) {
+                    setShortLinkError('That short link is already taken.');
+                    return;
+                }
+                if (response.status === 400) {
+                    setShortLinkError('Use 2-40 letters, numbers, or hyphens.');
+                    return;
+                }
+                throw new Error('Failed to save short link');
             }
             const data = await response.json();
             const nextShortUrl = `${window.location.origin}${data.shortPath}`;
             setShortShareUrl(nextShortUrl);
+            setShortCodeDraft(data.shortCode);
             try {
                 await navigator.clipboard.writeText(nextShortUrl);
                 setShortLinkCopied(true);
@@ -751,11 +766,19 @@ const DiscussionPage = () => {
                 setError('Short link generated, but could not copy it automatically.');
             }
         } catch (err) {
-            console.error('Failed to generate short link:', err);
-            setError('Could not generate the short link.');
+            console.error('Failed to save short link:', err);
+            setError('Could not save the short link.');
         } finally {
             setShortLinkLoading(false);
         }
+    };
+
+    const handleGenerateShortLink = async () => {
+        await saveShortLink();
+    };
+
+    const handleSaveCustomShortLink = async () => {
+        await saveShortLink(shortCodeDraft);
     };
 
     const handleCopyShortLink = async () => {
@@ -1708,37 +1731,72 @@ const DiscussionPage = () => {
                             <div className="mb-4 max-w-2xl mx-auto rounded-md border border-indigo-100 bg-indigo-50 p-3 text-left">
                                 <div className="mb-2 flex items-center justify-between gap-3">
                                     <p className="text-sm font-semibold text-indigo-800">Short link</p>
-                                    {!shortShareUrl && (
-                                        <button
-                                            type="button"
-                                            onClick={handleGenerateShortLink}
-                                            disabled={shortLinkLoading}
-                                            className="shrink-0 px-3 py-1.5 rounded bg-indigo-600 text-white text-sm hover:bg-indigo-700 disabled:opacity-60"
-                                        >
-                                            {shortLinkLoading ? 'Generating…' : 'Generate'}
-                                        </button>
-                                    )}
+                                    <button
+                                        type="button"
+                                        onClick={handleGenerateShortLink}
+                                        disabled={shortLinkLoading}
+                                        className="shrink-0 px-3 py-1.5 rounded bg-white border border-indigo-300 text-indigo-700 text-sm hover:bg-indigo-100 disabled:opacity-60"
+                                    >
+                                        {shortLinkLoading ? 'Saving…' : 'Generate'}
+                                    </button>
                                 </div>
-                                {shortShareUrl ? (
-                                    <div className="flex items-center gap-2">
+                                <div className="space-y-2">
+                                    <div className="flex items-center gap-0">
+                                        <span
+                                            className="max-w-[55%] shrink-0 truncate rounded-l border border-r-0 border-gray-300 bg-white px-2 py-2 text-sm text-gray-500"
+                                            title={shortUrlPrefix}
+                                        >
+                                            {shortUrlPrefix}
+                                        </span>
                                         <input
                                             type="text"
-                                            readOnly
-                                            value={shortShareUrl}
+                                            value={shortCodeDraft}
+                                            onChange={(e) => {
+                                                const next = e.target.value
+                                                    .toLowerCase()
+                                                    .replace(/^https?:\/\/[^/]+\/?/i, '')
+                                                    .replace(/^s\//i, '')
+                                                    .replace(/^\/+/, '');
+                                                setShortCodeDraft(next);
+                                                setShortLinkError('');
+                                            }}
+                                            placeholder="ai"
                                             onFocus={(e) => e.target.select()}
-                                            className="flex-1 min-w-0 p-2 border rounded text-sm bg-white"
+                                            className="flex-1 min-w-0 p-2 border text-sm bg-white"
                                         />
                                         <button
                                             type="button"
-                                            onClick={handleCopyShortLink}
-                                            className="shrink-0 px-3 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700 whitespace-nowrap text-sm"
+                                            onClick={handleSaveCustomShortLink}
+                                            disabled={shortLinkLoading || !shortCodeDraft.trim()}
+                                            className="shrink-0 px-3 py-2 bg-indigo-600 text-white rounded-r hover:bg-indigo-700 whitespace-nowrap text-sm disabled:opacity-60"
                                         >
-                                            {shortLinkCopied ? 'Copied!' : 'Copy'}
+                                            Save
                                         </button>
                                     </div>
-                                ) : (
-                                    <p className="text-sm text-indigo-700">Create a shorter join URL for messages, slides, and room displays.</p>
-                                )}
+                                    {shortLinkError && (
+                                        <p className="text-sm text-red-600">{shortLinkError}</p>
+                                    )}
+                                    {shortShareUrl ? (
+                                        <div className="flex items-center gap-2">
+                                            <input
+                                                type="text"
+                                                readOnly
+                                                value={shortShareUrl}
+                                                onFocus={(e) => e.target.select()}
+                                                className="flex-1 min-w-0 p-2 border rounded text-sm bg-white"
+                                            />
+                                            <button
+                                                type="button"
+                                                onClick={handleCopyShortLink}
+                                                className="shrink-0 px-3 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700 whitespace-nowrap text-sm"
+                                            >
+                                                {shortLinkCopied ? 'Copied!' : 'Copy'}
+                                            </button>
+                                        </div>
+                                    ) : (
+                                        <p className="text-sm text-indigo-700">Create a shorter join URL for messages, slides, and room displays.</p>
+                                    )}
+                                </div>
                             </div>
                         )}
                         <button

--- a/client/src/DiscussionPage.jsx
+++ b/client/src/DiscussionPage.jsx
@@ -185,6 +185,9 @@ const DiscussionPage = () => {
     const [showActionsMenu, setShowActionsMenu] = useState(false);
     const [presence, setPresence] = useState(0);
     const [copied, setCopied] = useState(false);
+    const [shortShareUrl, setShortShareUrl] = useState('');
+    const [shortLinkLoading, setShortLinkLoading] = useState(false);
+    const [shortLinkCopied, setShortLinkCopied] = useState(false);
     const [adminToken, setAdminToken] = useState(null);
     // Mirror of adminToken readable inside async callbacks, so an in-flight
     // checkModerator ack can tell whether the token it verified is still current.
@@ -237,6 +240,15 @@ const DiscussionPage = () => {
     const adminUrl = typeof window !== 'undefined' && adminToken
         ? `${window.location.origin}/discussion/${discussionSlug}?admin=${adminToken}`
         : '';
+
+    useEffect(() => {
+        setShortShareUrl(
+            typeof window !== 'undefined' && discussion?.short_code
+                ? `${window.location.origin}/s/${discussion.short_code}`
+                : ''
+        );
+        setShortLinkCopied(false);
+    }, [discussionSlug, discussion?.short_code]);
 
     const handleCopyLink = async () => {
         try {
@@ -712,6 +724,49 @@ const DiscussionPage = () => {
         } catch (err) {
             console.error('Failed to copy admin link:', err);
             setError('Could not copy the moderator link.');
+        }
+    };
+
+    const handleGenerateShortLink = async () => {
+        if (!adminToken || shortLinkLoading) return;
+        setShortLinkLoading(true);
+        try {
+            const response = await fetch(`/api/discussions/${encodeURIComponent(discussionSlug)}/short-link`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ adminToken }),
+            });
+            if (!response.ok) {
+                throw new Error('Failed to generate short link');
+            }
+            const data = await response.json();
+            const nextShortUrl = `${window.location.origin}${data.shortPath}`;
+            setShortShareUrl(nextShortUrl);
+            try {
+                await navigator.clipboard.writeText(nextShortUrl);
+                setShortLinkCopied(true);
+                setTimeout(() => setShortLinkCopied(false), 2000);
+            } catch (copyErr) {
+                console.error('Failed to copy generated short link:', copyErr);
+                setError('Short link generated, but could not copy it automatically.');
+            }
+        } catch (err) {
+            console.error('Failed to generate short link:', err);
+            setError('Could not generate the short link.');
+        } finally {
+            setShortLinkLoading(false);
+        }
+    };
+
+    const handleCopyShortLink = async () => {
+        if (!shortShareUrl) return;
+        try {
+            await navigator.clipboard.writeText(shortShareUrl);
+            setShortLinkCopied(true);
+            setTimeout(() => setShortLinkCopied(false), 2000);
+        } catch (err) {
+            console.error('Failed to copy short link:', err);
+            setError('Could not copy the short link. You can select and copy it manually.');
         }
     };
 
@@ -1649,6 +1704,43 @@ const DiscussionPage = () => {
                                 {copied ? 'Copied!' : 'Copy'}
                             </button>
                         </div>
+                        {isAdmin && (
+                            <div className="mb-4 max-w-2xl mx-auto rounded-md border border-indigo-100 bg-indigo-50 p-3 text-left">
+                                <div className="mb-2 flex items-center justify-between gap-3">
+                                    <p className="text-sm font-semibold text-indigo-800">Short link</p>
+                                    {!shortShareUrl && (
+                                        <button
+                                            type="button"
+                                            onClick={handleGenerateShortLink}
+                                            disabled={shortLinkLoading}
+                                            className="shrink-0 px-3 py-1.5 rounded bg-indigo-600 text-white text-sm hover:bg-indigo-700 disabled:opacity-60"
+                                        >
+                                            {shortLinkLoading ? 'Generating…' : 'Generate'}
+                                        </button>
+                                    )}
+                                </div>
+                                {shortShareUrl ? (
+                                    <div className="flex items-center gap-2">
+                                        <input
+                                            type="text"
+                                            readOnly
+                                            value={shortShareUrl}
+                                            onFocus={(e) => e.target.select()}
+                                            className="flex-1 min-w-0 p-2 border rounded text-sm bg-white"
+                                        />
+                                        <button
+                                            type="button"
+                                            onClick={handleCopyShortLink}
+                                            className="shrink-0 px-3 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700 whitespace-nowrap text-sm"
+                                        >
+                                            {shortLinkCopied ? 'Copied!' : 'Copy'}
+                                        </button>
+                                    </div>
+                                ) : (
+                                    <p className="text-sm text-indigo-700">Create a shorter join URL for messages, slides, and room displays.</p>
+                                )}
+                            </div>
+                        )}
                         <button
                             onClick={() => setShowShareModal(false)}
                             className="px-4 py-2 bg-gray-300 rounded hover:bg-gray-400"

--- a/schema.sql
+++ b/schema.sql
@@ -9,6 +9,7 @@ CREATE TABLE IF NOT EXISTS discussions (
   id         SERIAL PRIMARY KEY,
   topic      TEXT NOT NULL,
   slug       TEXT,
+  short_code TEXT,
   created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
 );
 

--- a/server.js
+++ b/server.js
@@ -120,6 +120,18 @@ function suffixSlug(baseSlug, suffix) {
   return `${baseSlug.slice(0, 80 - suffixText.length)}${suffixText}`;
 }
 
+const SHORT_CODE_ALPHABET = '23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+const SHORT_CODE_LENGTH = 6;
+
+function generateShortCode() {
+  let code = '';
+  const bytes = crypto.randomBytes(SHORT_CODE_LENGTH);
+  for (const byte of bytes) {
+    code += SHORT_CODE_ALPHABET[byte % SHORT_CODE_ALPHABET.length];
+  }
+  return code;
+}
+
 function escapeCsv(value) {
   if (value === null || value === undefined) {
     return '';
@@ -628,7 +640,7 @@ function renderReportHtml(summary) {
 async function getDiscussionBySlug(slug) {
   const canonicalSlug = slugifyTopic(slug);
   const result = await pool.query(
-    'SELECT id, topic, slug, created_at FROM discussions WHERE slug = $1 ORDER BY id DESC LIMIT 1',
+    'SELECT id, topic, slug, short_code, created_at FROM discussions WHERE slug = $1 ORDER BY id DESC LIMIT 1',
     [canonicalSlug]
   );
   return result.rows[0] || null;
@@ -1674,6 +1686,28 @@ app.get('/api/discussions/resolve/:topic', async (req, res) => {
   }
 });
 
+app.post('/api/discussions/:topic/short-link', async (req, res) => {
+  try {
+    const result = await generateDiscussionShortCode(req.params.topic, req.body?.adminToken);
+    if (!result.success) {
+      if (result.error === 'not_authorized') {
+        return res.status(403).json({ error: 'Not authorized' });
+      }
+      return res.status(404).json({ error: 'Discussion not found' });
+    }
+
+    res.json({
+      success: true,
+      slug: result.slug,
+      shortCode: result.shortCode,
+      shortPath: `/s/${result.shortCode}`,
+    });
+  } catch (err) {
+    console.error('Error generating short link:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
 app.get('/api/discussions/:id', async (req, res) => {
   const { id } = req.params;
   try {
@@ -1681,7 +1715,7 @@ app.get('/api/discussions/:id', async (req, res) => {
     // the discussion id is discoverable via GET /api/discussions, so returning
     // the moderator secret here would let anyone claim moderator controls.
     const result = await pool.query(
-      'SELECT id, topic, slug, created_at, locked FROM discussions WHERE id = $1',
+      'SELECT id, topic, slug, short_code, created_at, locked FROM discussions WHERE id = $1',
       [id]
     );
     if (result.rows.length > 0) {
@@ -2183,6 +2217,12 @@ async function migrateDiscussionSlugs() {
   }
 }
 
+async function migrateDiscussionShortCodes() {
+  await pool.query('ALTER TABLE discussions ADD COLUMN IF NOT EXISTS short_code TEXT');
+  await pool.query('CREATE UNIQUE INDEX IF NOT EXISTS discussions_short_code_unique_idx ON discussions(short_code) WHERE short_code IS NOT NULL');
+  console.log('Discussion short-code migration completed');
+}
+
 function isSlugShapedLegacyTitle(topic) {
   const title = formatTopicTitle(topic);
   return title === slugifyTopic(title);
@@ -2506,6 +2546,58 @@ async function createDiscussion(topic) {
   } finally {
     client.release();
   }
+}
+
+async function generateDiscussionShortCode(topic, token) {
+  const discussionId = await verifyAdmin(topic, token);
+  if (!discussionId) {
+    return { success: false, error: 'not_authorized' };
+  }
+
+  const client = await pool.connect();
+  try {
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      await client.query('BEGIN');
+      try {
+        const existing = await client.query(
+          'SELECT slug, short_code FROM discussions WHERE id = $1 FOR UPDATE',
+          [discussionId]
+        );
+
+        if (existing.rows.length === 0) {
+          await client.query('ROLLBACK');
+          return { success: false, error: 'not_found' };
+        }
+
+        const row = existing.rows[0];
+        if (row.short_code) {
+          await client.query('COMMIT');
+          return { success: true, slug: row.slug, shortCode: row.short_code };
+        }
+
+        const shortCode = generateShortCode();
+        const updated = await client.query(
+          `UPDATE discussions
+              SET short_code = $1
+            WHERE id = $2
+            RETURNING slug, short_code`,
+          [shortCode, discussionId]
+        );
+        await client.query('COMMIT');
+        return { success: true, slug: updated.rows[0].slug, shortCode: updated.rows[0].short_code };
+      } catch (e) {
+        await client.query('ROLLBACK');
+        if (e.code === '23505') {
+          continue;
+        }
+        throw e;
+      }
+    }
+  } finally {
+    client.release();
+  }
+
+  throw new Error(`Could not generate a unique short code for discussion ${discussionId}`);
 }
 
 // First-come moderator claim: assigns a fresh admin token only if the
@@ -3510,6 +3602,24 @@ app.post('/api/duplicate-discussion', async (req, res) => {
   }
 });
 
+app.get('/s/:shortCode', async (req, res) => {
+  try {
+    const result = await pool.query(
+      'SELECT slug FROM discussions WHERE short_code = $1 LIMIT 1',
+      [req.params.shortCode]
+    );
+
+    if (result.rows.length === 0) {
+      return res.status(404).send('Short link not found');
+    }
+
+    res.redirect(302, `/discussion/${result.rows[0].slug}`);
+  } catch (err) {
+    console.error('Error resolving short link:', err);
+    res.status(500).send('Server error');
+  }
+});
+
 // Catch-all route
 app.get(/.*/, (req, res) => {
   res.sendFile(path.join(__dirname, 'dist', 'index.html'));
@@ -3536,6 +3646,7 @@ initSchema()
   .then(() => migrateModerationAndDedup())
   .then(() => migrateUniqueDiscussionTopics())
   .then(() => migrateDiscussionSlugs())
+  .then(() => migrateDiscussionShortCodes())
   .then(() => Promise.all([migrateAddPseudonymColumn(), migrateResponseVotesTable(), migrateModeratorsTable()]))
   .then(() => migrateDiscussionPseudonymsTable())
   .then(() => migrateBrainstormInteractions())

--- a/server.js
+++ b/server.js
@@ -122,6 +122,7 @@ function suffixSlug(baseSlug, suffix) {
 
 const SHORT_CODE_ALPHABET = '23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
 const SHORT_CODE_LENGTH = 6;
+const CUSTOM_SHORT_CODE_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,38}[a-z0-9])$/;
 
 function generateShortCode() {
   let code = '';
@@ -130,6 +131,19 @@ function generateShortCode() {
     code += SHORT_CODE_ALPHABET[byte % SHORT_CODE_ALPHABET.length];
   }
   return code;
+}
+
+function normalizeCustomShortCode(value) {
+  const trimmed = String(value || '').trim().toLowerCase();
+  if (!trimmed) return null;
+
+  const withoutOrigin = trimmed.replace(/^https?:\/\/[^/]+\/?/i, '');
+  const withoutPrefix = withoutOrigin.replace(/^s\//i, '');
+  return withoutPrefix.replace(/^\/+|\/+$/g, '');
+}
+
+function isValidCustomShortCode(value) {
+  return CUSTOM_SHORT_CODE_PATTERN.test(value);
 }
 
 function escapeCsv(value) {
@@ -1688,10 +1702,16 @@ app.get('/api/discussions/resolve/:topic', async (req, res) => {
 
 app.post('/api/discussions/:topic/short-link', async (req, res) => {
   try {
-    const result = await generateDiscussionShortCode(req.params.topic, req.body?.adminToken);
+    const result = await generateDiscussionShortCode(req.params.topic, req.body?.adminToken, req.body?.shortCode);
     if (!result.success) {
       if (result.error === 'not_authorized') {
         return res.status(403).json({ error: 'Not authorized' });
+      }
+      if (result.error === 'invalid') {
+        return res.status(400).json({ error: 'Use 2-40 letters, numbers, or hyphens; start and end with a letter or number.' });
+      }
+      if (result.error === 'taken') {
+        return res.status(409).json({ error: 'Short link already taken' });
       }
       return res.status(404).json({ error: 'Discussion not found' });
     }
@@ -2548,10 +2568,18 @@ async function createDiscussion(topic) {
   }
 }
 
-async function generateDiscussionShortCode(topic, token) {
+async function generateDiscussionShortCode(topic, token, requestedCode) {
   const discussionId = await verifyAdmin(topic, token);
   if (!discussionId) {
     return { success: false, error: 'not_authorized' };
+  }
+
+  const customCode = normalizeCustomShortCode(requestedCode);
+  if (requestedCode !== undefined && !customCode) {
+    return { success: false, error: 'invalid' };
+  }
+  if (customCode && !isValidCustomShortCode(customCode)) {
+    return { success: false, error: 'invalid' };
   }
 
   const client = await pool.connect();
@@ -2570,12 +2598,12 @@ async function generateDiscussionShortCode(topic, token) {
         }
 
         const row = existing.rows[0];
-        if (row.short_code) {
+        if (!customCode && row.short_code) {
           await client.query('COMMIT');
           return { success: true, slug: row.slug, shortCode: row.short_code };
         }
 
-        const shortCode = generateShortCode();
+        const shortCode = customCode || generateShortCode();
         const updated = await client.query(
           `UPDATE discussions
               SET short_code = $1
@@ -2587,6 +2615,9 @@ async function generateDiscussionShortCode(topic, token) {
         return { success: true, slug: updated.rows[0].slug, shortCode: updated.rows[0].short_code };
       } catch (e) {
         await client.query('ROLLBACK');
+        if (customCode && e.code === '23505') {
+          return { success: false, error: 'taken' };
+        }
         if (e.code === '23505') {
           continue;
         }

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -128,6 +128,25 @@ test('moderators can generate short links that redirect to the discussion', asyn
   const redirect = await fetch(`${baseUrl}${generated.body.shortPath}`, { redirect: 'manual' });
   assert.equal(redirect.status, 302);
   assert.equal(redirect.headers.get('location'), `/discussion/${slug}`);
+
+  const custom = await jsonRequest('POST', `/api/discussions/${slug}/short-link`, { adminToken, shortCode: 'AI' });
+  assert.equal(custom.status, 200);
+  assert.equal(custom.body.shortCode, 'ai');
+  assert.equal(custom.body.shortPath, '/s/ai');
+
+  const customRedirect = await fetch(`${baseUrl}/s/ai`, { redirect: 'manual' });
+  assert.equal(customRedirect.status, 302);
+  assert.equal(customRedirect.headers.get('location'), `/discussion/${slug}`);
+
+  const invalid = await jsonRequest('POST', `/api/discussions/${slug}/short-link`, { adminToken, shortCode: '-bad-' });
+  assert.equal(invalid.status, 400);
+
+  const other = await jsonRequest('POST', '/api/discussions', { topic: uniqueTopic('short-link-other') });
+  const taken = await jsonRequest('POST', `/api/discussions/${other.body.slug}/short-link`, {
+    adminToken: other.body.adminToken,
+    shortCode: 'ai',
+  });
+  assert.equal(taken.status, 409);
 });
 
 test('slug migration preserves literal slug-shaped legacy titles', async () => {

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -53,10 +53,11 @@ test('server startup creates schema and applies the pseudonym migration', async 
     SELECT column_name
     FROM information_schema.columns
     WHERE table_schema = 'public'
-      AND table_name = 'votes'
-      AND column_name = 'pseudonym'
+      AND ((table_name = 'votes' AND column_name = 'pseudonym')
+        OR (table_name = 'discussions' AND column_name = 'short_code'))
+    ORDER BY table_name, column_name
   `);
-  assert.equal(columns.rowCount, 1);
+  assert.deepEqual(columns.rows.map((row) => row.column_name), ['short_code', 'pseudonym']);
 });
 
 test('HTTP API creates and fetches discussions', async () => {
@@ -103,6 +104,30 @@ test('HTTP API resolves legacy title routes before falling back to canonical slu
   assert.equal(resolveSlug.status, 200);
   assert.equal(resolveSlug.body.topic, 'C++');
   assert.equal(resolveSlug.body.slug, 'c');
+});
+
+test('moderators can generate short links that redirect to the discussion', async () => {
+  const topic = uniqueTopic('short-link');
+  const createResponse = await jsonRequest('POST', '/api/discussions', { topic });
+  const { adminToken, slug } = createResponse.body;
+
+  const denied = await jsonRequest('POST', `/api/discussions/${slug}/short-link`, { adminToken: 'bogus-token' });
+  assert.equal(denied.status, 403);
+
+  const generated = await jsonRequest('POST', `/api/discussions/${slug}/short-link`, { adminToken });
+  assert.equal(generated.status, 200);
+  assert.equal(generated.body.success, true);
+  assert.equal(generated.body.slug, slug);
+  assert.match(generated.body.shortCode, /^[23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{6}$/);
+  assert.equal(generated.body.shortPath, `/s/${generated.body.shortCode}`);
+
+  const repeated = await jsonRequest('POST', `/api/discussions/${slug}/short-link`, { adminToken });
+  assert.equal(repeated.status, 200);
+  assert.equal(repeated.body.shortCode, generated.body.shortCode);
+
+  const redirect = await fetch(`${baseUrl}${generated.body.shortPath}`, { redirect: 'manual' });
+  assert.equal(redirect.status, 302);
+  assert.equal(redirect.headers.get('location'), `/discussion/${slug}`);
 });
 
 test('slug migration preserves literal slug-shaped legacy titles', async () => {


### PR DESCRIPTION
Adds moderator-generated short join links for discussions using app-local /s/<code> redirects. Moderators can generate a random code or save a custom available alias such as /s/ai, with validation and duplicate detection on the server. The share modal exposes generate, edit, save, and copy controls without changing participant or moderator-token links. Validated with npm run build and npm test.